### PR TITLE
Add class map based loading for Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,9 @@
 		"php": ">=5.3.0"
 	},
 	"autoload": {
-		"psr-0": {
-			"Credis": ""
-		}
+		"classmap": [
+			"Client.php",
+			"Cluster.php"
+		]
 	}
 }


### PR DESCRIPTION
Credis isn't PSR-0 compatible, so its files can't be autoloaded as such via Composer.

This pull request simply implements a static mapping of classes, as I thought it'd be easier than changing the structure of the repo (given it is two files)

/cc @rayward
