### PR TITLE
fwrite() infinite loop

### DIFF
--- a/Client.php
+++ b/Client.php
@@ -680,7 +680,7 @@ class Credis_Client {
         $commandLen = strlen($command);
         for ($written = 0; $written < $commandLen; $written += $fwrite) {
             $fwrite = fwrite($this->redis, substr($command, $written));
-            if ($fwrite === FALSE) {
+            if ($fwrite === FALSE || $fwrite == 0 ) {
                 throw new CredisException('Failed to write entire command to stream');
             }
         }


### PR DESCRIPTION
Based on this comment http://www.php.net/manual/en/function.fwrite.php#96951 there are cases where the client can loose connection to Redis and get stuck in an infinite loop.
