### PR TITLE
Allow setReadTimeout to accept -1 (for PHPRedis)

### DIFF
--- a/Client.php
+++ b/Client.php
@@ -386,16 +386,18 @@ class Credis_Client {
      */
     public function setReadTimeout($timeout)
     {
-        if ($timeout < 0) {
-            throw new CredisException('Negative read timeout values are not supported.');
+        if ($timeout < -1) {
+            throw new CredisException('Timeout values less than -1 are not accepted.');
         }
         $this->readTimeout = $timeout;
         if ($this->connected) {
             if ($this->standalone) {
+                $timeout = max($timeout, 0);
                 stream_set_timeout($this->redis, (int) floor($timeout), ($timeout - floor($timeout)) * 1000000);
             } else if (defined('Redis::OPT_READ_TIMEOUT')) {
-                // Not supported at time of writing, but hopefully this pull request will someday be merged:
-                // https://github.com/nicolasff/phpredis/pull/260
+                // supported in phpredis 2.2.3
+                // a timeout value of -1 means reads will not timeout
+                // see http://stackoverflow.com/questions/18072407/php-redis-timeout-read-error-on-connection
                 $this->redis->setOption(Redis::OPT_READ_TIMEOUT, $timeout);
             }
         }

--- a/tests/CredisTest.php
+++ b/tests/CredisTest.php
@@ -57,6 +57,22 @@ class CredisTest extends PHPUnit_Framework_TestCase
     $this->credis->setReadTimeout(10);
   }
 
+  public function testPHPRedisReadTimeout() {
+    try {
+      $this->credis->forceStandalone = false;
+      $this->credis->setReadTimeout(-1);
+    } catch(CredisException $e) {
+      $this->fail('setReadTimeout should accept -1 as timeout value');
+    }
+    try {
+      $this->credis->setReadTimeout(-2);
+      $this->fail('setReadTimeout should not accept values less than -1');
+    } catch(CredisException $e) {
+    }
+
+    $this->credis->setReadTimeout(10);
+  }
+
   public function testScalars()
   {
     // Basic get/set


### PR DESCRIPTION
The `setReadTimeout` method doesn't accept values less than 0, but the PHPRedis `Redis::OPT_READ_TIMEOUT` option does seem to accept -1. PHPRedis treats -1 as no timeout, whereas it treats 0 as timeout immediately. The discrepancy is mentioned [in this Stack Overflow thread](http://stackoverflow.com/questions/18072407/php-redis-timeout-read-error-on-connection).

I'm not sure whether it would be better to check if Credis is in standalone mode first, and only accept -1 if not.
