### PR TITLE
Adding persistent support

### DIFF
--- a/Cluster.php
+++ b/Cluster.php
@@ -82,7 +82,7 @@ class Credis_Cluster
     ksort($this->ring, SORT_NUMERIC);
     $this->nodes = array_keys($this->ring);
     $this->dont_hash = array_flip(array(
-      'RANDOMKEY', 'DBSIZE',
+      'RANDOMKEY', 'DBSIZE', 'PIPELINE', 'EXEC',
       'SELECT',    'MOVE',    'FLUSHDB',  'FLUSHALL',
       'SAVE',      'BGSAVE',  'LASTSAVE', 'SHUTDOWN',
       'INFO',      'MONITOR', 'SLAVEOF'


### PR DESCRIPTION
The persistent flag is supported in the standalone client, but not in the cluster. Not sure if it makes sense to have it, but I added it anyway.

If this pull request is accepted, I'll add the persitent configuration option to the cluster implementation of Cm_Cache_Backend_Redis.

Thanks
Thijs
