### PR TITLE
remove Rwsplit.php from classmap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
 	"autoload": {
 		"classmap": [
 			"Client.php",
-            "Rwsplit.php",
 			"Cluster.php",
             "Sentinel.php"
 		]


### PR DESCRIPTION
I removed Rwsplit.php from classmap, because composer raises error:

```
[RuntimeException]                                                                                                                                                          
Could not scan for classes inside "/vendor/colinmollenhour/credis/Rwsplit.php" which does not appear to    be a file nor a folder 
```
