### PR TITLE
Fixed incorrect handling of timeout on subscribed channel

### DIFF
--- a/Client.php
+++ b/Client.php
@@ -600,6 +600,7 @@ class Credis_Client {
     {
     	list($command, $channel, $subscribedChannels) = $this->__call('punsubscribe', func_get_args());
     	$this->subscribed = $subscribedChannels > 0;
+    	return array($command, $channel, $subscribedChannels);
     }
 
     /**
@@ -654,6 +655,7 @@ class Credis_Client {
     {
     	list($command, $channel, $subscribedChannels) = $this->__call('unsubscribe', func_get_args());
     	$this->subscribed = $subscribedChannels > 0;
+    	return array($command, $channel, $subscribedChannels);
     }
 
     /**


### PR DESCRIPTION
If a subscribed channel times out the client attempts to unsubscribe.  However, in the change I made earlier the explicitly defined unsubscribe and pUnsubscribe commands did not return the status when it was called.  The effect of my error was that when a read timeout occurs the status value is null, not equaling zero (line 698) and another read is attempted inappropriately.  The unsubscribe commands should return the status so they can be handled properly internally.
