### PR TITLE
Fix for issue #38; option array with standalone mode

### DIFF
--- a/Client.php
+++ b/Client.php
@@ -827,28 +827,7 @@ class Credis_Client {
                     break;
             }
             // Flatten arguments
-            $argsFlat = NULL;
-            foreach($args as $index => $arg) {
-                if(is_array($arg)) {
-                    if($argsFlat === NULL) {
-                        $argsFlat = array_slice($args, 0, $index);
-                    }
-                    if($name == 'mset' || $name == 'msetnx' || $name == 'hmset') {
-                      foreach($arg as $key => $value) {
-                        $argsFlat[] = $key;
-                        $argsFlat[] = $value;
-                      }
-                    } else {
-                      $argsFlat = array_merge($argsFlat, $arg);
-                    }
-                } else if($argsFlat !== NULL) {
-                    $argsFlat[] = $arg;
-                }
-            }
-            if($argsFlat !== NULL) {
-                $args = $argsFlat;
-                $argsFlat = NULL;
-            }
+            $args = self::_flattenArguments($args);
 
             // In pipeline mode
             if($this->usePipeline)
@@ -995,21 +974,7 @@ class Credis_Client {
                     break;
                 default:
                     // Flatten arguments
-                    $argsFlat = NULL;
-                    foreach($args as $index => $arg) {
-                        if(is_array($arg)) {
-                            if($argsFlat === NULL) {
-                                $argsFlat = array_slice($args, 0, $index);
-                            }
-                            $argsFlat = array_merge($argsFlat, $arg);
-                        } else if($argsFlat !== NULL) {
-                            $argsFlat[] = $arg;
-                        }
-                    }
-                    if($argsFlat !== NULL) {
-                        $args = $argsFlat;
-                        $argsFlat = NULL;
-                    }
+                    $args = self::_flattenArguments($args);
             }
 
             try {
@@ -1256,4 +1221,28 @@ class Credis_Client {
         return sprintf('$%d%s%s', strlen($arg), CRLF, $arg);
     }
 
+    /**
+     * Flatten arguments
+     *
+     * If an argument is an array, the key is inserted as argument followed by the array values
+     *  array('zrangebyscore', '-inf', 123, array('limit' => array('0', '1')))
+     * becomes
+     *  array('zrangebyscore', '-inf', 123, 'limit', '0', '1')
+     *
+     * @param array $in
+     * @return array
+     */
+    private static function _flattenArguments(array $in, &$out = array())
+    {
+        foreach ($in as $key => $val) {
+            if (is_array($val)) {
+                $out[] = $key;
+                self::_flattenArguments($val, $out);
+            } else {
+                $out[] = $val;
+            }
+        }
+
+        return $out;
+    }
 }

--- a/Client.php
+++ b/Client.php
@@ -1232,14 +1232,17 @@ class Credis_Client {
      * @param array $in
      * @return array
      */
-    private static function _flattenArguments(array $in, &$out = array())
+    private static function _flattenArguments(array $arguments, &$out = array())
     {
-        foreach ($in as $key => $val) {
-            if (is_array($val)) {
+        foreach ($arguments as $key => $arg) {
+            if (!is_int($key)) {
                 $out[] = $key;
-                self::_flattenArguments($val, $out);
+            }
+            
+            if (is_array($arg)) {
+                self::_flattenArguments($arg, $out);
             } else {
-                $out[] = $val;
+                $out[] = $arg;
             }
         }
 


### PR DESCRIPTION
Split flattening arguments into separate recursive method
Instead of testing for command name (mset, msetnx and hmset) checking for numeric array key to decide whether to add it as an argument or not.

Fixed the problems I had in standalone mode. Not excessively tested with php-redis extension