### PR TITLE
Fixed zrangebyscore for phpRedis

### DIFF
--- a/Client.php
+++ b/Client.php
@@ -140,6 +140,7 @@ class CredisException extends Exception
  * @method int           rPushX(string $key, mixed $value)
  *
  * Sorted Sets:
+ * @method array         zrangebyscore(string $key, mixed $start, mixed $stop, array $args = null)
  * TODO
  *
  * Pub/Sub
@@ -903,6 +904,23 @@ class Credis_Client {
                         $response = false;
                     }
                     break;
+                case 'zrangebyscore';
+                    if (in_array('withscores', $args, true)) {
+                        // Map array of values into key=>score list like phpRedis does
+                        $item = null;
+                        $out = array();
+                        foreach ($response as $value) {
+                            if ($item == null) {
+                                $item = $value;
+                            } else {
+                                // 2nd value is the score
+                                $out[$value] = (float) $item;
+                                $item = null;
+                            }
+                        }
+                        $response = $out;
+                    }
+                    break;
             }
 
             // Watch mode disables reconnect so error is thrown
@@ -935,6 +953,18 @@ class Credis_Client {
                 case 'hmset':
                 case 'hmget':
                 case 'del':
+                case 'zrangebyscore':
+                    if (isset($args[3]) && is_array($args[3])) {
+                        // map options
+                        $cArgs = array();
+                        if (in_array('withscores', $args[3])) {
+                            $cArgs['withscores'] = true;
+                        }
+                        if (array_key_exists('limit', $args[3])) {
+                            $cArgs['limit'] = $args[3]['limit'];
+                        }
+                        $args[3] = $cArgs;
+                    }
                     break;
                 case 'mget':
                     if(isset($args[0]) && ! is_array($args[0])) {

--- a/Client.php
+++ b/Client.php
@@ -914,7 +914,7 @@ class Credis_Client {
                                 $item = $value;
                             } else {
                                 // 2nd value is the score
-                                $out[$value] = (float) $item;
+                                $out[$item] = (float) $value;
                                 $item = null;
                             }
                         }

--- a/tests/CredisTest.php
+++ b/tests/CredisTest.php
@@ -129,6 +129,37 @@ class CredisTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(array(), $this->credis->sMembers('noexist'));
     }
 
+    public function testSortedSets()
+    {
+        $this->assertEquals(1, $this->credis->zAdd('myset', 1, 'Hello'));
+        $this->assertEquals(1, $this->credis->zAdd('myset', 2.123, 'World'));
+        $this->assertEquals(1, $this->credis->zAdd('myset', 10, 'And'));
+        $this->assertEquals(1, $this->credis->zAdd('myset', 11, 'Goodbye'));
+
+        $this->assertEquals(4, count($this->credis->zRangeByScore('myset', '-inf', '+inf')));
+        $this->assertEquals(2, count($this->credis->zRangeByScore('myset', '1', '9')));
+
+        $range = $this->credis->zRangeByScore('myset', '-inf', '+inf', array('limit' => array(1, 2)));
+        $this->assertEquals(2, count($range));
+        $this->assertEquals('World', $range[0]);
+        $this->assertEquals('And', $range[1]);
+
+        $range = $this->credis->zRangeByScore('myset', '-inf', '+inf', array('withscores', 'limit' => array(1, 2)));
+        $this->assertEquals(2, count($range));
+        $this->assertTrue(array_key_exists('World', $range));
+        $this->assertEquals(2.123, $range['World']);
+        $this->assertTrue(array_key_exists('And', $range));
+        $this->assertEquals(10, $range['And']);
+
+        $range = $this->credis->zRangeByScore('myset', 10, '+inf', array('withscores'));
+        $this->assertEquals(2, count($range));
+        $this->assertTrue(array_key_exists('And', $range));
+        $this->assertEquals(10, $range['And']);
+        $this->assertTrue(array_key_exists('Goodbye', $range));
+        $this->assertEquals(11, $range['Goodbye']);
+
+    }
+
     public function testHashes()
     {
         $this->assertEquals(1, $this->credis->hSet('hash','field1','foo'));


### PR DESCRIPTION
Two fixes;

Fixed zrangebyscore not working when providing the options 'withscores' and/or 'limit' while using the phpRedis extension,  by reformatting the argument array before passing it to phpRedis.
> Warning: Redis::zRangeByScore() expects at most 4 parameters, 6 given

Fixed the return value for zrangebyscore  when using 'withscores' in standalone mode to be the same as phpRedis; The array key is the item and it's value the score.