### PR TITLE
Arguments for zrangebyscore to be equal to php-redis

### DIFF
--- a/Client.php
+++ b/Client.php
@@ -826,6 +826,19 @@ class Credis_Client {
                     }
                     $args = $eArgs;
                     break;
+                case 'zrangebyscore':
+                    if (isset($args[3]) && is_array($args[3])) {
+                        // map options
+                        $cArgs = array();
+                        if (!empty($args[3]['withscores'])) {
+                            $cArgs[] = 'withscores';
+                        }
+                        if (array_key_exists('limit', $args[3])) {
+                            $cArgs[] = array('limit' => $args[3]['limit']);
+                        }
+                        $args[3] = $cArgs;
+                    }
+                    break;
             }
             // Flatten arguments
             $args = self::_flattenArguments($args);
@@ -954,17 +967,6 @@ class Credis_Client {
                 case 'hmget':
                 case 'del':
                 case 'zrangebyscore':
-                    if (isset($args[3]) && is_array($args[3])) {
-                        // map options
-                        $cArgs = array();
-                        if (in_array('withscores', $args[3])) {
-                            $cArgs['withscores'] = true;
-                        }
-                        if (array_key_exists('limit', $args[3])) {
-                            $cArgs['limit'] = $args[3]['limit'];
-                        }
-                        $args[3] = $cArgs;
-                    }
                     break;
                 case 'mget':
                     if(isset($args[0]) && ! is_array($args[0])) {

--- a/tests/CredisTest.php
+++ b/tests/CredisTest.php
@@ -159,8 +159,14 @@ class CredisTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(11, $range['Goodbye']);
 
         // withscores-option is off
-        $range = $this->credis->zRangeByScore('myset', '-inf', '+inf', array('withscores' => true));
+        $range = $this->credis->zRangeByScore('myset', '-inf', '+inf', array('withscores'));
         $this->assertEquals(4, count($range));
+        $this->assertEquals(range(0, 3), array_keys($range)); // expecting numeric array without scores
+        
+        $range = $this->credis->zRangeByScore('myset', '-inf', '+inf', array('withscores' => false));
+        $this->assertEquals(4, count($range));
+        $this->assertEquals(range(0, 3), array_keys($range)); 
+
     }
 
     public function testHashes()

--- a/tests/CredisTest.php
+++ b/tests/CredisTest.php
@@ -144,20 +144,23 @@ class CredisTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('World', $range[0]);
         $this->assertEquals('And', $range[1]);
 
-        $range = $this->credis->zRangeByScore('myset', '-inf', '+inf', array('withscores', 'limit' => array(1, 2)));
+        $range = $this->credis->zRangeByScore('myset', '-inf', '+inf', array('withscores' => true, 'limit' => array(1, 2)));
         $this->assertEquals(2, count($range));
         $this->assertTrue(array_key_exists('World', $range));
         $this->assertEquals(2.123, $range['World']);
         $this->assertTrue(array_key_exists('And', $range));
         $this->assertEquals(10, $range['And']);
 
-        $range = $this->credis->zRangeByScore('myset', 10, '+inf', array('withscores'));
+        $range = $this->credis->zRangeByScore('myset', 10, '+inf', array('withscores' => true));
         $this->assertEquals(2, count($range));
         $this->assertTrue(array_key_exists('And', $range));
         $this->assertEquals(10, $range['And']);
         $this->assertTrue(array_key_exists('Goodbye', $range));
         $this->assertEquals(11, $range['Goodbye']);
 
+        // withscores-option is off
+        $range = $this->credis->zRangeByScore('myset', '-inf', '+inf', array('withscores' => true));
+        $this->assertEquals(4, count($range));
     }
 
     public function testHashes()


### PR DESCRIPTION
I made a boo-boo with the 'withscores' option. Credis now expects another inputformat than the php-redis extension does. I fixed this by adding my workaround in the standalone mode instead, so Credis and php-redis are interchangeable.

This is a breaking change though, and will break implementations using 'withscores' since pull request #44 was merged. But I hope you consider 'fixing' this inconsistency.