### PR TITLE
Use correct database for every client in cluster.

### DIFF
--- a/Cluster.php
+++ b/Cluster.php
@@ -50,6 +50,12 @@ class Credis_Cluster
   protected $dont_hash;
 
   /**
+   * Currently working cluster-wide database number.
+   * @var int
+   */
+  protected $selectedDb = 0;
+
+  /**
    * Creates an interface to a cluster of Redis servers
    * Each server should be in the format:
    *  array(
@@ -208,6 +214,15 @@ class Credis_Cluster
   }
 
   /**
+   * @param int $index
+   * @return void
+   */
+  public function select($index)
+  {
+      $this->selectedDb = (int) $index;
+  }
+
+  /**
    * Execute a Redis command on the cluster with automatic consistent hashing and read/write splitting
    *
    * @param string $name
@@ -223,6 +238,10 @@ class Credis_Cluster
     }
     else {
       $client = $this->byHash($args[0]);
+    }
+    // Ensure that current client is working on the same database as expected.
+    if ($client->getSelectedDb() != $this->selectedDb) {
+      $client->select($this->selectedDb);
     }
     return call_user_func_array([$client, $name], $args);
   }


### PR DESCRIPTION
Hi there. Thank you for the neat library!

I'm using a Redis cluster with Sentinel and here what I've found:

```
$sentinel = new Credis_Sentinel(new Credis_Client('127.0.0.1',26379));
$masterAddress = $sentinel->getMasterAddressByName('mymaster');
$cluster = $sentinel->getCluster('mymaster'); // - right here that cluster will use one of the slave client.
$cluster->select(6); // -- we want to use 6-th database
$cluster->get('test'); // Cluster will read from 6-th database which was selected on slave's $client after creation, everything is ok :-)
$cluster->set('test', '123'); // - right here cluster will write to master but master's $selectedDb is on zero database. Oops.
```
So without this commit all the data goes into default (zero) database.
With this commit all data goes to separate databases as it should be.

Probably the "better" solution would be to select database on client creation and switch all active $clients on select() to reduce overhead checks on every query. I was afraid to break something while making a quite big refactoring of the code.

Sorry I can't provide a test case because I have no idea how it could be tested. You need a master+slave+sentinel setup for the right test environment. But it was tested and it works on my staging env though (I will deploy it to production soon).
