### PR TITLE
Debug hscan

### DIFF
--- a/Client.php
+++ b/Client.php
@@ -636,7 +636,7 @@ class Credis_Client {
 	 * @param int $Iterator
 	 * @param string $field
 	 * @param string $pattern
-	 * @param int $Iterator
+	 * @param int $count
 	 * @return bool | Array
 	 */
 	public function hscan(&$Iterator, $field, $pattern = null, $count = null)

--- a/Client.php
+++ b/Client.php
@@ -633,15 +633,16 @@ class Credis_Client {
     }
 
     /**
-     * @param int $Iterator
-     * @param string $pattern
-     * @param int $Iterator
-     * @return bool | Array
-     */    
-    public function hscan(&$Iterator, $pattern = null, $count = null)
-    {
-        return $this->__call('hscan', array(&$Iterator, $pattern, $count));
-    }
+	 * @param int $Iterator
+	 * @param string $field
+	 * @param string $pattern
+	 * @param int $Iterator
+	 * @return bool | Array
+	 */
+	public function hscan(&$Iterator, $field, $pattern = null, $count = null)
+	{
+		return $this->__call('hscan', array(&$Iterator,$field, $pattern, $count));
+	}
     
     /**
      * @param int $Iterator
@@ -810,7 +811,6 @@ class Credis_Client {
                     break;
                 case 'scan':
                 case 'sscan':
-                case 'hscan':
                 case 'zscan':
                     $ref =& $args[0];
                     if (empty($ref))
@@ -830,6 +830,25 @@ class Credis_Client {
                     }
                     $args = $eArgs;
                     break;
+                case 'hscan':
+					$ref =& $args[0];
+					if (empty($ref))
+					{
+						$ref = 0;
+					}
+					$eArgs = array($args[1],$ref);
+					if (!empty($args[2]))
+					{
+						$eArgs[] = 'MATCH';
+						$eArgs[] = $args[2];
+					}
+					if (!empty($args[3]))
+					{
+						$eArgs[] = 'COUNT';
+						$eArgs[] = $args[4];
+					}
+					$args = $eArgs;
+					break;
                 case 'zrangebyscore':
                 case 'zrevrangebyscore':
                 case 'zrange':
@@ -916,7 +935,6 @@ class Credis_Client {
             {
                 case 'scan':
                 case 'sscan':
-                case 'hscan':
                 case 'zscan':
                     $ref = array_shift($response);
                     if (empty($ref))
@@ -924,6 +942,15 @@ class Credis_Client {
                         $response = false;
                     }
                     break;
+                case 'hscan':
+					$response   = $response[1];
+					$count  = count($response);
+					$out    = [];
+					for($i  = 0;$i < $count;$i+=2){
+						$out[$response[$i]] = $response[$i+1];
+					}
+					$response= $out;
+					break;
                 case 'zrangebyscore':
                 case 'zrevrangebyscore':
                     if (in_array('withscores', $args, true)) {

--- a/tests/CredisTest.php
+++ b/tests/CredisTest.php
@@ -388,4 +388,10 @@ class CredisTest extends PHPUnit_Framework_TestCase
       $this->setExpectedException('CredisException','Cannot force Credis_Client to use standalone PHP driver after a connection has already been established.');
       $this->credis->forceStandalone();
   }
+  public function testHscan()
+  {
+      $this->credis->hmset('hash','name','Jack','age',33);
+      $result = $this->credis->hscan($a,'hash','n*');
+      $this->assertEquals($result,['name'=>'Jack']);
+	}
 }


### PR DESCRIPTION
Hi
I had a problem with last code's hscan and I fixed that problem
hscan is different from other scans it must have a field too, you can read end of scan's documentation for more details.
I don't know about zscan and sscan but I know last code about hscan was wrong and it caused exception with message `invalid cursor` and it's because of wrong command:
```
127.0.0.1:6379[1]> hscan 0 match qti3e.*
(error) ERR invalid cursor
127.0.0.1:6379[1]> hscan users 0 match qti3e.*
1) "0"
2) 1) "qti3e.fname"
   2) "Alireza"
   3) "qti3e.lname"
   4) "Ghadimi"
   5) "qti3e.email"
   6) "qti3eqti3e@gmail.com"
127.0.0.1:6379[1]>
```