### PR TITLE
Update hscan/sscan/zscan/scan, Fix compatibility with phpredis

### DIFF
--- a/Client.php
+++ b/Client.php
@@ -641,29 +641,31 @@ class Credis_Client {
 	 */
 	public function hscan(&$Iterator, $field, $pattern = null, $count = null)
 	{
-		return $this->__call('hscan', array(&$Iterator,$field, $pattern, $count));
+		return $this->__call('hscan', array($field, &$Iterator, $pattern, $count));
 	}
     
     /**
      * @param int $Iterator
+     * @param string $field
      * @param string $pattern
      * @param int $Iterator
      * @return bool | Array
      */    
-    public function sscan(&$Iterator, $pattern = null, $count = null)
+    public function sscan(&$Iterator, $field, $pattern = null, $count = null)
     {
-        return $this->__call('sscan', array(&$Iterator, $pattern, $count));
+        return $this->__call('sscan', array($field, &$Iterator, $pattern, $count));
     }
     
     /**
      * @param int $Iterator
+     * @param string $field
      * @param string $pattern
      * @param int $Iterator
      * @return bool | Array
      */    
-    public function zscan(&$Iterator, $pattern = null, $count = null)
+    public function zscan(&$Iterator, $field, $pattern = null, $count = null)
     {
-        return $this->__call('zscan', array(&$Iterator, $pattern, $count));
+        return $this->__call('zscan', array($field, &$Iterator, $pattern, $count));
     }
 
     /**
@@ -810,8 +812,6 @@ class Credis_Client {
                     }
                     break;
                 case 'scan':
-                case 'sscan':
-                case 'zscan':
                     $ref =& $args[0];
                     if (empty($ref))
                     {
@@ -830,13 +830,15 @@ class Credis_Client {
                     }
                     $args = $eArgs;
                     break;
+                case 'sscan':
+                case 'zscan':
                 case 'hscan':
-					$ref =& $args[0];
+					$ref =& $args[1];
 					if (empty($ref))
 					{
 						$ref = 0;
 					}
-					$eArgs = array($args[1],$ref);
+					$eArgs = array($args[0],$ref);
 					if (!empty($args[2]))
 					{
 						$eArgs[] = 'MATCH';
@@ -935,21 +937,22 @@ class Credis_Client {
             {
                 case 'scan':
                 case 'sscan':
-                case 'zscan':
                     $ref = array_shift($response);
-                    if (empty($ref))
-                    {
-                        $response = false;
-                    }
+                    $response = empty($response[0]) ? array() : $response[0];
                     break;
                 case 'hscan':
-					$response   = $response[1];
-					$count  = count($response);
-					$out    = [];
-					for($i  = 0;$i < $count;$i+=2){
-						$out[$response[$i]] = $response[$i+1];
-					}
-					$response= $out;
+                case 'zscan':
+                    $ref = array_shift($response);
+                    $response = empty($response[0]) ? array() : $response[0];
+                    if (!empty($response) && is_array($response))
+                    {
+                        $count  = count($response);
+                        $out    = array();
+                        for($i  = 0;$i < $count;$i+=2){
+                            $out[$response[$i]] = $response[$i+1];
+                        }
+                        $response = $out;
+                    }
 					break;
                 case 'zrangebyscore':
                 case 'zrevrangebyscore':

--- a/tests/CredisTest.php
+++ b/tests/CredisTest.php
@@ -390,8 +390,37 @@ class CredisTest extends PHPUnit_Framework_TestCase
   }
   public function testHscan()
   {
-      $this->credis->hmset('hash','name','Jack','age',33);
-      $result = $this->credis->hscan($a,'hash','n*');
+      $this->credis->hmset('hash',array('name' => 'Jack','age' =>33));
+      $iterator = null;
+      $result = $this->credis->hscan($iterator,'hash','n*');
+      $this->assertEquals($iterator,0);
       $this->assertEquals($result,['name'=>'Jack']);
 	}
+    public function testSscan()
+    {
+        $this->credis->sadd('set','name','Jack');
+        $this->credis->sadd('set','age','33');
+        $iterator = null;
+        $result = $this->credis->sscan($iterator,'set','n*');
+        $this->assertEquals($iterator,0);
+        $this->assertEquals($result,[0=>'name']);
+    }
+    public function testZscan()
+    {
+        $this->credis->zadd('sortedset',0,'name');
+        $this->credis->zadd('sortedset',1,'age');
+        $iterator = null;
+        $result = $this->credis->zscan($iterator,'sortedset','n*');
+        $this->assertEquals($iterator,0);
+        $this->assertEquals($result,['name'=>'0']);
+    }
+    public function testscan()
+    {
+        $this->credis->set('name','Jack');
+        $this->credis->set('age','33');
+        $iterator = null;
+        $result = $this->credis->scan($iterator,'n*');
+        $this->assertEquals($iterator,0);
+        $this->assertEquals($result,['name']);
+    }
 }


### PR DESCRIPTION
- Remove php +5.4 array construction.
- Fix scan in standalone mode, it was truncating results or returning an array in an array.
- Fix sscan and zscan as they where missing an argument.
- Ensure phpredis mode works with hscan/sscan/zscan.
 - requires arguments in a different order, swapping them in the custom function is the most-sane way to swap the reference around.
- Ensures that the iterator reference is updated in standalone mode, as redis is permitted to return empty arrays. Only when the iterator returns zero is there nothing left.
- Added tests for basic usage of all the functions.