### PR TITLE
Include host:port in the connection error message

### DIFF
--- a/Client.php
+++ b/Client.php
@@ -451,7 +451,7 @@ class Credis_Client {
             }
             $failures = $this->connectFailures;
             $this->connectFailures = 0;
-            throw new CredisException("Connection to Redis failed after $failures failures." . (isset($errno) && isset($errstr) ? "Last Error : ({$errno}) {$errstr}" : ""));
+            throw new CredisException("Connection to Redis {$this->host}:{$this->port} failed after $failures failures." . (isset($errno) && isset($errstr) ? "Last Error : ({$errno}) {$errstr}" : ""));
         }
 
         $this->connectFailures = 0;


### PR DESCRIPTION
With Cm_Cache_Backend_Redis supporting having initial sentinel support, reporting which host failed to connect is now useful