### PR TITLE
Ignore keys for mget like phpredis does.

### DIFF
--- a/Client.php
+++ b/Client.php
@@ -867,6 +867,12 @@ class Credis_Client {
                         $args[3] = $cArgs;
                     }
                     break;
+                case 'mget':
+                    if (isset($args[0]) && is_array($args[0])) 
+                    {
+                        $args = array_values($args[0]);
+                    }
+                    break;
             }
             // Flatten arguments
             $args = self::_flattenArguments($args);


### PR DESCRIPTION
There is a test for mget in standalone mode but it is broken.

At some stage I'll look into setting up Travis-ci or similar for build tests