### PR TITLE
Improve retry logic

### DIFF
--- a/Client.php
+++ b/Client.php
@@ -533,7 +533,7 @@ class Credis_Client {
             } catch (Exception $e) {
                 ; // Ignore exceptions on close
             }
-            $this->connected = $this->usePipeline = $this->isMulti = FALSE;
+            $this->connected = $this->usePipeline = $this->isMulti = $this->isWatching = FALSE;
         }
         return $result;
     }
@@ -1177,7 +1177,6 @@ class Credis_Client {
     {
         // Reconnect on lost connection (Redis server "timeout" exceeded since last command)
         if(feof($this->redis)) {
-            $this->close();
             // If a watch or transaction was in progress and connection was lost, throw error rather than reconnect
             // since transaction/watch state will be lost.
             if(($this->isMulti && ! $this->usePipeline) || $this->isWatching) {

--- a/Client.php
+++ b/Client.php
@@ -436,9 +436,19 @@ class Credis_Client {
             if ( ! $this->redis) {
                 $this->redis = new Redis;
             }
-            $result = $this->persistent
-                ? $this->redis->pconnect($this->host, $this->port, $this->timeout, $this->persistent)
-                : $this->redis->connect($this->host, $this->port, $this->timeout);
+            try
+            {
+                $result = $this->persistent
+                    ? $this->redis->pconnect($this->host, $this->port, $this->timeout, $this->persistent)
+                    : $this->redis->connect($this->host, $this->port, $this->timeout);
+            }
+            catch(Exception $e)
+            {
+                // Some applications will capture the php error that phpredis can sometimes generate and throw it as an Exception
+                $result = false;
+                $errno = 1;
+                $errstr = $e->getMessage();
+            }
         }
 
         // Use recursion for connection retries


### PR DESCRIPTION
- Handle is an application convert a php error into an Exception 
- per https://github.com/colinmollenhour/credis/issues/76 the connection can get into an unknowable state in the event of a read-timeout. The safe solution is to close the connection and cleanup the library state so a re-connection can be safely done.
 - A persistent socket which has a read-timeout can leave data to be read across requests, which is obviously deeply undesirable.  should be closed in the event of an error to remove any errors from a previous use of that socket.
 - [x] setup a test to use lua to sleep + return some data to test that attempting to close to socket will correctly cleanup a persistent socket, and that the library doesn't need to send a quit command to get redis to terminate the connection.