### PR TITLE
Allow count to be used in sscan, hscan and zscan

### DIFF
--- a/Client.php
+++ b/Client.php
@@ -860,7 +860,7 @@ class Credis_Client {
 					if (!empty($args[3]))
 					{
 						$eArgs[] = 'COUNT';
-						$eArgs[] = $args[4];
+						$eArgs[] = $args[3];
 					}
 					$args = $eArgs;
 					break;

--- a/tests/CredisTest.php
+++ b/tests/CredisTest.php
@@ -424,7 +424,7 @@ class CredisTest extends PHPUnit_Framework_TestCase
   {
       $this->credis->hmset('hash',array('name' => 'Jack','age' =>33));
       $iterator = null;
-      $result = $this->credis->hscan($iterator,'hash','n*');
+      $result = $this->credis->hscan($iterator,'hash','n*',10);
       $this->assertEquals($iterator,0);
       $this->assertEquals($result,['name'=>'Jack']);
 	}
@@ -433,7 +433,7 @@ class CredisTest extends PHPUnit_Framework_TestCase
         $this->credis->sadd('set','name','Jack');
         $this->credis->sadd('set','age','33');
         $iterator = null;
-        $result = $this->credis->sscan($iterator,'set','n*');
+        $result = $this->credis->sscan($iterator,'set','n*',10);
         $this->assertEquals($iterator,0);
         $this->assertEquals($result,[0=>'name']);
     }
@@ -442,7 +442,7 @@ class CredisTest extends PHPUnit_Framework_TestCase
         $this->credis->zadd('sortedset',0,'name');
         $this->credis->zadd('sortedset',1,'age');
         $iterator = null;
-        $result = $this->credis->zscan($iterator,'sortedset','n*');
+        $result = $this->credis->zscan($iterator,'sortedset','n*',10);
         $this->assertEquals($iterator,0);
         $this->assertEquals($result,['name'=>'0']);
     }
@@ -451,7 +451,7 @@ class CredisTest extends PHPUnit_Framework_TestCase
         $this->credis->set('name','Jack');
         $this->credis->set('age','33');
         $iterator = null;
-        $result = $this->credis->scan($iterator,'n*');
+        $result = $this->credis->scan($iterator,'n*',10);
         $this->assertEquals($iterator,0);
         $this->assertEquals($result,['name']);
     }


### PR DESCRIPTION
The sscan, hscan and zscan methods all take 4 arguments:

iterator
field
pattern
count

They simply wrap the __call function with the appropriate redis method
name. Count is always passed as 4th element in the argument array, eg:
$args[3].

The code in __call will check for a non-empty value in $args[3], and
then use $args[4] as the value for COUNT. As $args[4] can never be set,
this is always null, and causes an array reference warning, as well as
a syntax error with the sscan/hscan/zscan method.

This update takes the count value from $args[3], where it is set by the
wrapper methods.

Additionally, the tests have been updated to include a count so that
this kind of issue will be picked up in the future if there are any
regressions.