### PR TITLE
HHVM Compat: Do not pass null timeout value to connect() or pconnect()

### DIFF
--- a/Client.php
+++ b/Client.php
@@ -436,9 +436,10 @@ class Credis_Client {
             if ( ! $this->redis) {
                 $this->redis = new Redis;
             }
+            $socketTimeout = $this->timeout ? $this->timeout : 0.0;
             $result = $this->persistent
-                ? $this->redis->pconnect($this->host, $this->port, $this->timeout, $this->persistent)
-                : $this->redis->connect($this->host, $this->port, $this->timeout);
+                ? $this->redis->pconnect($this->host, $this->port, $socketTimeout, $this->persistent)
+                : $this->redis->connect($this->host, $this->port, $socketTimeout);
         }
 
         // Use recursion for connection retries


### PR DESCRIPTION
This is a silly change that fixes HHVM throwing up with the following error if no explicit timeout was set:

    Fatal error: Uncaught TypeError: Argument 5 passed to fsockopen() must be an instance of float, null given in /vendor/colinmollenhour/credis/Client.php:441