### PR TITLE
Fix standalone mode hMSet

### DIFF
--- a/Client.php
+++ b/Client.php
@@ -897,6 +897,17 @@ class Credis_Client {
                         $args = array_values($args[0]);
                     }
                     break;
+                case 'hmset':
+                    if (isset($args[1]) && is_array($args[1]))
+                    {
+                        $cArgs = array();
+                        foreach($args[1] as $id => $value)
+                        {
+                            $cArgs[] = $id;
+                            $cArgs[] = $value;
+                        }
+                        $args[1] = $cArgs;
+                    }
             }
             // Flatten arguments
             $args = self::_flattenArguments($args);

--- a/tests/CredisTest.php
+++ b/tests/CredisTest.php
@@ -212,6 +212,10 @@ class CredisTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(array(), $this->credis->hGetAll('nohash'));
         $this->assertEquals(array('field1' => 'foo', 'field2' => 'Hello', 'field3' => 'World'), $this->credis->hGetAll('hash'));
 
+        // test integer keys
+        $this->assertTrue($this->credis->hMSet('hashInt', array(0 => 'Hello', 1 => 'World')));
+        $this->assertEquals(array(0 => 'Hello', 1 => 'World'), $this->credis->hGetAll('hashInt'));
+
         // Test long hash values
         $longString = str_repeat(md5('asd'), 4096); // 128k (redis.h REDIS_INLINE_MAX_SIZE = 64k)
         $this->assertEquals(1, $this->credis->hMSet('long_hash', array('count' => 1, 'data' => $longString)), 'Set long hash value');


### PR DESCRIPTION
hmset's 2nd argument is an array of key/value pairs. The key can be integers, so needs special handling vs just using _flattenArguments