### PR TITLE
Hmget

### DIFF
--- a/Client.php
+++ b/Client.php
@@ -928,7 +928,10 @@ class Credis_Client {
                     $name = 'zrem';
                 case 'hmget':
                     // hmget needs to track the keys for rehydrating the results
-                    $trackedArgs = array_keys($args);
+                    if (isset($args[1]))
+                    {
+                        $trackedArgs = $args[1];
+                    }
                     break;
             }
             // Flatten arguments
@@ -955,7 +958,7 @@ class Credis_Client {
                     // Read response
                     $response = array();
                     foreach($this->commandNames as $command) {
-                        list($name, $arguments) = $command; 
+                        list($name, $arguments) = $command;
                         $response[] = $this->read_reply($name, $arguments);
                     }
                     $this->commandNames = NULL;
@@ -971,7 +974,7 @@ class Credis_Client {
                         $this->isMulti = TRUE;
                     }
                     array_unshift($args, $this->getRenamedCommand($name));
-                    $this->commandNames[] = array($name, $trackArgInPipeline);
+                    $this->commandNames[] = array($name, $trackedArgs);
                     $this->commands .= self::_prepare_command($args);
                     return $this;
                 }

--- a/Client.php
+++ b/Client.php
@@ -807,6 +807,7 @@ class Credis_Client {
         // Send request via native PHP
         if($this->standalone)
         {
+            $trackedArgs = array();
             switch ($name) {
                 case 'eval':
                 case 'evalsha':
@@ -925,6 +926,9 @@ class Credis_Client {
                     break;
                 case 'zdelete':
                     $name = 'zrem';
+                case 'hmget':
+                    // hmget needs to track the keys for rehydrating the results
+                    $trackedArgs = array_keys($args);
                     break;
             }
             // Flatten arguments
@@ -938,7 +942,7 @@ class Credis_Client {
                 }
                 else if($name == 'exec') {
                     if($this->isMulti) {
-                        $this->commandNames[] = $name;
+                        $this->commandNames[] = array($name, $trackedArgs);
                         $this->commands .= self::_prepare_command(array($this->getRenamedCommand($name)));
                     }
 
@@ -951,7 +955,8 @@ class Credis_Client {
                     // Read response
                     $response = array();
                     foreach($this->commandNames as $command) {
-                        $response[] = $this->read_reply($command);
+                        list($name, $arguments) = $command; 
+                        $response[] = $this->read_reply($name, $arguments);
                     }
                     $this->commandNames = NULL;
 
@@ -966,7 +971,7 @@ class Credis_Client {
                         $this->isMulti = TRUE;
                     }
                     array_unshift($args, $this->getRenamedCommand($name));
-                    $this->commandNames[] = $name;
+                    $this->commandNames[] = array($name, $trackArgInPipeline);
                     $this->commands .= self::_prepare_command($args);
                     return $this;
                 }
@@ -1182,10 +1187,6 @@ class Credis_Client {
             // change return values where it is too difficult to minim in standalone mode
             switch($name)
             {
-                case 'hmget':
-                    $response = array_values($response);
-                    break;
-
                 case 'type':
                     $typeMap = array(
                       self::TYPE_NONE,
@@ -1256,7 +1257,7 @@ class Credis_Client {
         }
     }
 
-    protected function read_reply($name = '')
+    protected function read_reply($name = '', $arguments = array())
     {
         $reply = fgets($this->redis);
         if($reply === FALSE) {
@@ -1348,6 +1349,10 @@ class Credis_Client {
                 if($response === -1) {
                     $response = FALSE;
                 }
+                break;
+            case 'hmget':
+                // rehydrate results into key => value form
+                $response = array_combine($arguments, $response);
                 break;
         }
 

--- a/Client.php
+++ b/Client.php
@@ -1354,6 +1354,10 @@ class Credis_Client {
                 }
                 break;
             case 'hmget':
+                if (count($arguments) != count($response))
+                {
+                    throw new CredisException('hmget arguments and response do not match: '.print_r($arguments, TRUE). ' ' .print_r($response, TRUE));
+                }
                 // rehydrate results into key => value form
                 $response = array_combine($arguments, $response);
                 break;

--- a/Client.php
+++ b/Client.php
@@ -998,7 +998,7 @@ class Credis_Client {
             array_unshift($args, $this->getRenamedCommand($name));
             $command = self::_prepare_command($args);
             $this->write_command($command);
-            $response = $this->read_reply($name);
+            $response = $this->read_reply($name, $trackedArgs);
 
             switch($name)
             {

--- a/tests/CredisStandaloneTest.php
+++ b/tests/CredisStandaloneTest.php
@@ -27,7 +27,7 @@ class CredisStandaloneTest extends CredisTest
     public function testStandAloneArgumentsExtra()
     {
         $this->assertTrue($this->credis->hMSet('hash', array('field1' => 'value1', 'field2' => 'value2'), 'field3', 'value3'));
-        $this->assertEquals(array('value1','value2','value3'), $this->credis->hMGet('hash', array('field1','field2','field3')));
+        $this->assertEquals(array('field1' => 'value1', 'field2' => 'value2', 'field3' =>'value3'), $this->credis->hMGet('hash', array('field1','field2','field3')));
     }
     public function testStandAloneMultiPipelineThrowsException()
     {

--- a/tests/CredisTest.php
+++ b/tests/CredisTest.php
@@ -208,7 +208,7 @@ class CredisTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('foo', $this->credis->hGet('hash','field1'));
         $this->assertEquals(NULL, $this->credis->hGet('hash','x'));
         $this->assertTrue($this->credis->hMSet('hash', array('field2' => 'Hello', 'field3' => 'World')));
-        $this->assertEquals(array('foo','Hello',FALSE), $this->credis->hMGet('hash', array('field1','field2','nilfield')));
+        $this->assertEquals(array('field1' => 'foo', 'field2' => 'Hello', 'nilfield' => FALSE), $this->credis->hMGet('hash', array('field1','field2','nilfield')));
         $this->assertEquals(array(), $this->credis->hGetAll('nohash'));
         $this->assertEquals(array('field1' => 'foo', 'field2' => 'Hello', 'field3' => 'World'), $this->credis->hGetAll('hash'));
 


### PR DESCRIPTION
phpredis's return result for [hmget](https://github.com/phpredis/phpredis#hmget) is an array of key/values preserving the original keys.


As documented in https://github.com/colinmollenhour/credis/issues/84 credis is inconsistent in pipeline mode with phpredis enabled, and does not match this spec in standalone mode.

This code change requires more testing, as it was a quick fix.