### PR TITLE
Update unit tests for phpredis 3.1.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,6 @@ php:
   - 7.1
   - 7.2
 
-matrix:
-  allow_failures:
-    - php: 7.0
-    - php: 7.1
-    - php: 7.2
-
 install:
   - yes '' | pecl install -f redis
   - wget http://download.redis.io/releases/redis-3.2.11.tar.gz


### PR DESCRIPTION
phpredis 3.1.4 has been released as stable, so non of the tests should fail now.