### PR TITLE
Adding support for Client.php to work across fork()s

### DIFF
--- a/Client.php
+++ b/Client.php
@@ -537,7 +537,7 @@ class Credis_Client {
     {
         $result = TRUE;
         if ($this->redis && ($force || $this->isConnected() && ! $this->persistent)) {
-            if ($pid === getmypid()) {
+            if ($this->pid === getmypid()) {
                 try {
                     if (is_callable(array($this->redis, 'close'))) {
                         $this->redis->close();

--- a/Client.php
+++ b/Client.php
@@ -222,6 +222,11 @@ class Credis_Client {
      */
     protected $connected = FALSE;
 
+    /**
+     * Process ID of the connection.
+     * So we don't accidentally use the same connection after fork.
+     * @var null|int
+    */
     protected $pid;
 
     /**

--- a/Client.php
+++ b/Client.php
@@ -537,7 +537,7 @@ class Credis_Client {
     {
         $result = TRUE;
         if ($this->redis && ($force || $this->isConnected() && ! $this->persistent)) {
-            if ($pid === getmypid) {
+            if ($pid === getmypid()) {
                 try {
                     if (is_callable(array($this->redis, 'close'))) {
                         $this->redis->close();

--- a/Client.php
+++ b/Client.php
@@ -222,6 +222,8 @@ class Credis_Client {
      */
     protected $connected = FALSE;
 
+    protected $pid;
+
     /**
      * @var bool
      */
@@ -427,9 +429,14 @@ class Credis_Client {
      */
     public function connect()
     {
+        $currentpid = getmypid();
         if ($this->connected) {
-            return $this;
+            if ($currentpid === $this->pid) {
+                return $this;
+            }
+            $this->connected = false;
         }
+        $this->pid = $currentpid;
         $this->close(true);
 
         if ($this->standalone) {


### PR DESCRIPTION
We had a problem (race condition) using this module in our application because it shares the connection if you have a Credis_Client object when fork()ing.

This quick patch fixes that by storing the pid of the connection, and checking that pid everytime it checks to see if it is connected.
