### PR TITLE
Fix scan commands when using native php extension redis client.

### DIFF
--- a/Client.php
+++ b/Client.php
@@ -1099,7 +1099,8 @@ class Credis_Client {
                 case 'hscan':
                 case 'zscan':
                     // allow phpredis to see the caller's reference
-                    //$param_ref =& $args[0];
+                    $ref = array_shift($args);
+                    $args = array_merge([&$ref], $args);
                     break;
                 default:
                     // Flatten arguments


### PR DESCRIPTION
The native redis client expects that the iterator variable will be passed by reference, not value.  Without this change you will receive the following error if you attempt to us the scan family of commands:

PHP Error[2]: Parameter 1 to Redis::scan() expected to be a reference, value given
    in file /usr/local/eti_deploy/releases/4/vendor/colinmollenhour/credis/Client.php at line 1139