### PR TITLE
Add script for running unit tests locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 phpunit.phar
+phpunit_*.log

--- a/phpunit_local.sh
+++ b/phpunit_local.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# This script runs unit tests locally in environment similar to Travis-CI
+# It runs tests in different PHP versions with suitable PHPUnite version.
+#
+# You can see results of unit tests execution in console.
+# Also all execution logs are saved to files phpunit_<date-time>.log
+#
+# Prerequisites for running unit tests on local machine:
+#  - docker
+#  - docker-compose
+#
+# You can find definition of all test environments in folder testenv/
+# This folder is not automatically synced with .travis.yml
+# If you add new PHP version to .travis.yml then you'll need to adjust files in testenv/
+
+cd testenv
+
+# build containers and run tests
+docker-compose build && docker-compose up
+
+# save logs to log file
+docker-compose logs --no-color --timestamps | sort >"../phpunit_$(date '+%Y%m%d-%H%M%S').log"
+
+# remove containers
+docker-compose rm -f

--- a/testenv/docker-compose.yml
+++ b/testenv/docker-compose.yml
@@ -1,0 +1,27 @@
+version: '2'
+services:
+
+  php-55:
+    build: env/php-5.5/
+    volumes:
+      - ../:/src/
+
+  php-56:
+    build: env/php-5.6/
+    volumes:
+      - ../:/src/
+
+  php-70:
+    build: env/php-7.0/
+    volumes:
+      - ../:/src/
+
+  php-71:
+    build: env/php-7.1/
+    volumes:
+      - ../:/src/
+
+  php-72:
+    build: env/php-7.2/
+    volumes:
+      - ../:/src/

--- a/testenv/env/php-5.5/Dockerfile
+++ b/testenv/env/php-5.5/Dockerfile
@@ -1,0 +1,24 @@
+FROM php:5.5
+ENV phpunit_verison 4.8
+ENV redis_version 4.0.11
+
+RUN apt-get update && \
+    apt-get install -y wget
+
+RUN wget https://phar.phpunit.de/phpunit-${phpunit_verison}.phar && \
+    chmod +x phpunit-${phpunit_verison}.phar && \
+    mv phpunit-${phpunit_verison}.phar /usr/local/bin/phpunit
+
+# install php extension
+RUN yes '' | pecl install -f redis && \
+    docker-php-ext-enable redis
+
+# install redis server
+RUN wget http://download.redis.io/releases/redis-${redis_version}.tar.gz && \
+    tar -xzf redis-${redis_version}.tar.gz && \
+    make -s -C redis-${redis_version} -j
+
+CMD PATH=$PATH:/usr/local/bin/:/redis-${redis_version}/src/ && \
+    cp -rp /src /app && \
+    cd /app && \
+    phpunit

--- a/testenv/env/php-5.6/Dockerfile
+++ b/testenv/env/php-5.6/Dockerfile
@@ -1,0 +1,24 @@
+FROM php:5.6
+ENV phpunit_verison 5.7
+ENV redis_version 4.0.11
+
+RUN apt-get update && \
+    apt-get install -y wget
+
+RUN wget https://phar.phpunit.de/phpunit-${phpunit_verison}.phar && \
+    chmod +x phpunit-${phpunit_verison}.phar && \
+    mv phpunit-${phpunit_verison}.phar /usr/local/bin/phpunit
+
+# install php extension
+RUN yes '' | pecl install -f redis && \
+    docker-php-ext-enable redis
+
+# install redis server
+RUN wget http://download.redis.io/releases/redis-${redis_version}.tar.gz && \
+    tar -xzf redis-${redis_version}.tar.gz && \
+    make -s -C redis-${redis_version} -j
+
+CMD PATH=$PATH:/usr/local/bin/:/redis-${redis_version}/src/ && \
+    cp -rp /src /app && \
+    cd /app && \
+    phpunit

--- a/testenv/env/php-7.0/Dockerfile
+++ b/testenv/env/php-7.0/Dockerfile
@@ -1,0 +1,24 @@
+FROM php:7.0
+ENV phpunit_verison 6.4
+ENV redis_version 4.0.11
+
+RUN apt-get update && \
+    apt-get install -y wget
+
+RUN wget https://phar.phpunit.de/phpunit-${phpunit_verison}.phar && \
+    chmod +x phpunit-${phpunit_verison}.phar && \
+    mv phpunit-${phpunit_verison}.phar /usr/local/bin/phpunit
+
+# install php extension
+RUN yes '' | pecl install -f redis && \
+    docker-php-ext-enable redis
+
+# install redis server
+RUN wget http://download.redis.io/releases/redis-${redis_version}.tar.gz && \
+    tar -xzf redis-${redis_version}.tar.gz && \
+    make -s -C redis-${redis_version} -j
+
+CMD PATH=$PATH:/usr/local/bin/:/redis-${redis_version}/src/ && \
+    cp -rp /src /app && \
+    cd /app && \
+    phpunit

--- a/testenv/env/php-7.1/Dockerfile
+++ b/testenv/env/php-7.1/Dockerfile
@@ -1,0 +1,24 @@
+FROM php:7.1
+ENV phpunit_verison 6.4
+ENV redis_version 4.0.11
+
+RUN apt-get update && \
+    apt-get install -y wget
+
+RUN wget https://phar.phpunit.de/phpunit-${phpunit_verison}.phar && \
+    chmod +x phpunit-${phpunit_verison}.phar && \
+    mv phpunit-${phpunit_verison}.phar /usr/local/bin/phpunit
+
+# install php extension
+RUN yes '' | pecl install -f redis && \
+    docker-php-ext-enable redis
+
+# install redis server
+RUN wget http://download.redis.io/releases/redis-${redis_version}.tar.gz && \
+    tar -xzf redis-${redis_version}.tar.gz && \
+    make -s -C redis-${redis_version} -j
+
+CMD PATH=$PATH:/usr/local/bin/:/redis-${redis_version}/src/ && \
+    cp -rp /src /app && \
+    cd /app && \
+    phpunit

--- a/testenv/env/php-7.2/Dockerfile
+++ b/testenv/env/php-7.2/Dockerfile
@@ -1,0 +1,24 @@
+FROM php:7.2
+ENV phpunit_verison 8.0
+ENV redis_version 4.0.11
+
+RUN apt-get update && \
+    apt-get install -y wget
+
+RUN wget https://phar.phpunit.de/phpunit-${phpunit_verison}.phar && \
+    chmod +x phpunit-${phpunit_verison}.phar && \
+    mv phpunit-${phpunit_verison}.phar /usr/local/bin/phpunit
+
+# install php extension
+RUN yes '' | pecl install -f redis && \
+    docker-php-ext-enable redis
+
+# install redis server
+RUN wget http://download.redis.io/releases/redis-${redis_version}.tar.gz && \
+    tar -xzf redis-${redis_version}.tar.gz && \
+    make -s -C redis-${redis_version} -j
+
+CMD PATH=$PATH:/usr/local/bin/:/redis-${redis_version}/src/ && \
+    cp -rp /src /app && \
+    cd /app && \
+    phpunit


### PR DESCRIPTION
Script phpunit_local.sh runs unit tests locally in environment similar to Travis-CI
It runs tests in different PHP versions with suitable PHPUnite version.

You can see results of unit tests execution in console.
Also all execution logs are saved to files phpunit_<date-time>.log

Prerequisites for running unit tests on local machine:

 - docker
 - docker-compose

You can find definition of all test environments in folder testenv/
This folder is not automatically synced with .travis.yml
If you add new PHP version to .travis.yml then you'll need to adjust files in testenv/