### PR TITLE
Fix PHP 7.2 / PHPUnit 8.0 compatibility in unit tests

### DIFF
--- a/tests/CredisClusterTest.php
+++ b/tests/CredisClusterTest.php
@@ -9,15 +9,15 @@ class CredisClusterTest extends CredisTestCommon
   /** @var Credis_Cluster */
   protected $cluster;
 
-  protected function setUp()
+  protected function setUpOverride()
   {
-    parent::setUp();
+    parent::setUpOverride();
 
     $clients = array_slice($this->redisConfig,0,4);
     $this->cluster = new Credis_Cluster($clients,2,$this->useStandalone);
   }
 
-  protected function tearDown()
+  protected function tearDownOverride()
   {
     if($this->cluster) {
       $this->cluster->flushAll();

--- a/tests/CredisSentinelTest.php
+++ b/tests/CredisSentinelTest.php
@@ -12,9 +12,9 @@ class CredisSentinelTest extends CredisTestCommon
 
   protected $sentinelConfig;
 
-  protected function setUp()
+  protected function setUpOverride()
   {
-    parent::setUp();
+    parent::setUpOverride();
     if($this->sentinelConfig === NULL) {
       $configFile = dirname(__FILE__).'/sentinel_config.json';
       if( ! file_exists($configFile) || ! ($config = file_get_contents($configFile))) {
@@ -32,9 +32,9 @@ class CredisSentinelTest extends CredisTestCommon
     $this->waitForSlaveReplication();
   }
 
-  public static function setUpBeforeClass()
+  public static function setUpBeforeClassOverride()
   {
-    parent::setUpBeforeClass();
+    parent::setUpBeforeClassOverride();
     if(preg_match('/^WIN/',strtoupper(PHP_OS))){
       echo "\tredis-server redis-sentinel.conf --sentinel".PHP_EOL.PHP_EOL;
     } else {
@@ -47,9 +47,9 @@ class CredisSentinelTest extends CredisTestCommon
     }
   }
 
-  public static function tearDownAfterClass()
+  public static function tearDownAfterClassOverride()
   {
-    parent::tearDownAfterClass();
+    parent::tearDownAfterClassOverride();
     if(preg_match('/^WIN/',strtoupper(PHP_OS))){
       echo "Please kill all Redis instances manually:".PHP_EOL;
     } else {
@@ -59,7 +59,7 @@ class CredisSentinelTest extends CredisTestCommon
     }
   }
 
-  protected function tearDown()
+  protected function tearDownOverride()
   {
     if($this->sentinel) {
       $this->sentinel = NULL;

--- a/tests/CredisStandaloneClusterTest.php
+++ b/tests/CredisStandaloneClusterTest.php
@@ -5,7 +5,7 @@ require_once dirname(__FILE__).'/CredisClusterTest.php';
 class CredisStandaloneClusterTest extends CredisClusterTest
 {
   protected $useStandalone = TRUE;
-  protected function tearDown()
+  protected function tearDownOverride()
   {
     if($this->cluster) {
         foreach($this->cluster->clients() as $client){

--- a/tests/CredisTest.php
+++ b/tests/CredisTest.php
@@ -8,16 +8,16 @@ class CredisTest extends CredisTestCommon
     /** @var Credis_Client */
     protected $credis;
 
-    protected function setUp()
+    protected function setUpOverride()
     {
-        parent::setUp();
+        parent::setUpOverride();
         $this->credis = new Credis_Client($this->redisConfig[0]['host'], $this->redisConfig[0]['port'], $this->redisConfig[0]['timeout']);
         if($this->useStandalone) {
             $this->credis->forceStandalone();
         }
         $this->credis->flushDb();
     }
-    protected function tearDown()
+    protected function tearDownOverride()
     {
         if($this->credis) {
             $this->credis->close();

--- a/tests/CredisTestCommon.php
+++ b/tests/CredisTestCommon.php
@@ -1,16 +1,28 @@
 <?php
-// backward compatibility (https://stackoverflow.com/a/42828632/187780)
-if (!class_exists('\PHPUnit\Framework\TestCase') && class_exists('\PHPUnit_Framework_TestCase')) {
-    class_alias('\PHPUnit_Framework_TestCase', '\PHPUnit\Framework\TestCase');
+
+/**
+ * php 7.2 / phpUnit 8.0 compat fix
+ * Dynamically define base class with right methods signature
+ */
+if (class_exists('\PHPUnit\Runner\Version')
+  && version_compare(\PHPUnit\Runner\Version::id(), '8.0', '>='))
+{
+  // php 7.2 / phpUnit 8.0 mode
+  require_once dirname(__FILE__).'/CredisTestCommonBase.php';
+  class CredisTestCommonProxy extends CredisTestCommonBase { }
+} else {
+  // legacy code compatibility mode
+  require_once dirname(__FILE__).'/CredisTestCommonCompat.php';
+  class CredisTestCommonProxy extends CredisTestCommonCompat { }
 }
 
-class CredisTestCommon extends \PHPUnit\Framework\TestCase
+class CredisTestCommon extends CredisTestCommonProxy
 {
     protected $useStandalone = false;
     protected $redisConfig = null;
     protected $slaveConfig = null;
 
-    protected function setUp()
+    protected function setUpOverride()
     {
         if ($this->redisConfig === null)
         {
@@ -95,7 +107,7 @@ class CredisTestCommon extends \PHPUnit\Framework\TestCase
         return false;
     }
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClassOverride()
     {
         if(preg_match('/^WIN/',strtoupper(PHP_OS))){
             echo "Unit tests will not work automatically on Windows. Please setup all Redis instances manually:".PHP_EOL;
@@ -122,7 +134,7 @@ class CredisTestCommon extends \PHPUnit\Framework\TestCase
         }
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClassOverride()
     {
         if(preg_match('/^WIN/',strtoupper(PHP_OS))){
             echo "Please kill all Redis instances manually:".PHP_EOL;

--- a/tests/CredisTestCommonBase.php
+++ b/tests/CredisTestCommonBase.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Base class - compatible with PHP 7.2 / PHPUnit 8.0
+ */
+class CredisTestCommonBase extends \PHPUnit\Framework\TestCase
+{
+  // define own set of setUp/tearDown methods with unified signatures to fix PHP 7.2 / PHPUnit 8.0 compatibility issue
+  protected function setUpOverride() { }
+  protected function tearDownOverride() { }
+  public static function setUpBeforeClassOverride() { }
+  public static function tearDownAfterClassOverride() { }
+
+  protected function setUp(): void
+  {
+    $this->setUpOverride(); // proxy call to method with unified signature
+  }
+
+  protected function tearDown(): void
+  {
+    $this->tearDownOverride(); // proxy call to method with unified signature
+  }
+
+  public static function setUpBeforeClass(): void
+  {
+    static::setUpBeforeClassOverride(); // proxy call to method with unified signature
+  }
+
+  public static function tearDownAfterClass(): void
+  {
+    static::tearDownAfterClassOverride(); // proxy call to method with unified signature
+  }
+}

--- a/tests/CredisTestCommonCompat.php
+++ b/tests/CredisTestCommonCompat.php
@@ -1,0 +1,37 @@
+<?php
+// backward compatibility (https://stackoverflow.com/a/42828632/187780)
+if (!class_exists('\PHPUnit\Framework\TestCase') && class_exists('\PHPUnit_Framework_TestCase')) {
+  class_alias('\PHPUnit_Framework_TestCase', '\PHPUnit\Framework\TestCase');
+}
+
+/**
+ * Base class - compatible with everything before PHP 7.2 / PHPUnit 8.0
+ */
+abstract class CredisTestCommonCompat extends \PHPUnit\Framework\TestCase
+{
+  // define own set of setUp/tearDown methods with unified signatures to fix PHP 7.2 / PHPUnit 8.0 compatibility issue
+  protected function setUpOverride() { }
+  protected function tearDownOverride() { }
+  public static function setUpBeforeClassOverride() { }
+  public static function tearDownAfterClassOverride() { }
+
+  protected function setUp()
+  {
+    $this->setUpOverride(); // proxy call to method with unified signature
+  }
+
+  protected function tearDown()
+  {
+    $this->tearDownOverride(); // proxy call to method with unified signature
+  }
+
+  public static function setUpBeforeClass()
+  {
+    static::setUpBeforeClassOverride(); // proxy call to method with unified signature
+  }
+
+  public static function tearDownAfterClass()
+  {
+    static::tearDownAfterClassOverride(); // proxy call to method with unified signature
+  }
+}


### PR DESCRIPTION
Hi there,

I've tried to figure out the simplest fix for PHP 7.2 / PHPUnit 8 without total code duplication.
I've used proxy base class technique for this.

Pls check it when you have time

Cheers, 
Andrey