### PR TITLE
Enable encrypted connections with TLS

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -26,6 +26,39 @@ Credis_Client also supports transparent command renaming. Write code using the o
 client will send the aliased commands to the server transparently. Specify the renamed commands using a prefix
 for md5, a callable function, individual aliases, or an array map of aliases. See "Redis Security":http://redis.io/topics/security for more info.
 
+## Supported connection string formats
+
+```php
+$redis = new Credis_Client(/* connection string */);
+```
+
+### Unix socket connection string
+
+`unix:///path/to/redis.sock` 
+
+### TCP connection string
+
+`tcp://host[:port][/persistence_identifier]` 
+
+### TLS connection string
+
+`tls://host[:port][/persistence_identifier]` 
+
+#### Enable transport level security (TLS)
+
+Use TLS connection string `tls://127.0.0.1:6379` instead of TCP connection `tcp://127.0.0.1:6379` string in order to enable transport level security.
+
+```php
+require 'Credis/Client.php';
+$redis = new Credis_Client('tls://127.0.0.1:6379');
+$redis->set('awesome', 'absolutely');
+echo sprintf('Is Credis awesome? %s.\n', $redis->get('awesome'));
+
+// When arrays are given as arguments they are flattened automatically
+$redis->rpush('particles', array('proton','electron','neutron'));
+$particles = $redis->lrange('particles', 0, -1);
+```
+
 ## Clustering your servers
 
 Credis also includes a way for developers to fully utilize the scalability of Redis with multiple servers and [consistent hashing](http://en.wikipedia.org/wiki/Consistent_hashing).

--- a/tests/CredisTest.php
+++ b/tests/CredisTest.php
@@ -651,6 +651,27 @@ class CredisTest extends CredisTestCommon
       $this->assertEquals('abc123',$this->credis->getPersistence());
   }
 
+  public function testConnectionStringsTls()
+  {
+      $this->credis->close();
+      $this->credis = new Credis_Client('tls://'.$this->redisConfig[0]['host'] . ':' . $this->redisConfig[0]['port']);
+      if ($this->useStandalone) {
+          $this->credis->forceStandalone();
+      }
+      $this->assertEquals($this->credis->getHost(),$this->redisConfig[0]['host']);
+      $this->assertEquals($this->credis->getPort(),$this->redisConfig[0]['port']);
+      $this->credis = new Credis_Client('tls://'.$this->redisConfig[0]['host']);
+      if ($this->useStandalone) {
+          $this->credis->forceStandalone();
+      }
+      $this->assertEquals($this->credis->getPort(),$this->redisConfig[0]['port']);
+      $this->credis = new Credis_Client('tls://'.$this->redisConfig[0]['host'] . ':' . $this->redisConfig[0]['port'] . '/abc123');
+      if ($this->useStandalone) {
+          $this->credis->forceStandalone();
+      }
+      $this->assertEquals('abc123',$this->credis->getPersistence());
+  }
+
   /**
    * @group UnixSocket
    */
@@ -665,7 +686,7 @@ class CredisTest extends CredisTestCommon
       $this->assertEquals('value',$this->credis->get('key'));
   }
 
-  public function testInvalidTcpConnectionstring()
+  public function testInvalidTcpConnectionString()
   {
       $this->credis->close();
       $this->setExpectedExceptionShim('CredisException','Invalid host format; expected tcp://host[:port][/persistence_identifier]');
@@ -675,7 +696,17 @@ class CredisTest extends CredisTestCommon
       }
   }
 
-  public function testInvalidUnixSocketConnectionstring()
+  public function testInvalidTlsConnectionString()
+  {
+      $this->credis->close();
+      $this->setExpectedExceptionShim('CredisException','Invalid host format; expected tls://host[:port][/persistence_identifier]');
+      $this->credis = new Credis_Client('tls://'.$this->redisConfig[0]['host'] . ':abc');
+      if ($this->useStandalone) {
+          $this->credis->forceStandalone();
+      }
+  }
+
+  public function testInvalidUnixSocketConnectionString()
   {
       $this->credis->close();
       $this->setExpectedExceptionShim('CredisException','Invalid unix socket format; expected unix:///path/to/redis.sock');


### PR DESCRIPTION
Use standalone PHP driver because PHP Redis extension doesn't work with TLS.
Syntax `$redis = new Credis_Client('tls://host[:port][/persistence_identifier]')`