### PR TITLE
Add Credis_Client::VERSION constant

### DIFF
--- a/Client.php
+++ b/Client.php
@@ -168,12 +168,15 @@ class CredisException extends Exception
  */
 class Credis_Client {
 
+    const VERSION          = '1.11.1';
+
     const TYPE_STRING      = 'string';
     const TYPE_LIST        = 'list';
     const TYPE_SET         = 'set';
     const TYPE_ZSET        = 'zset';
     const TYPE_HASH        = 'hash';
     const TYPE_NONE        = 'none';
+
     const FREAD_BLOCK_SIZE = 8192;
 
     /**


### PR DESCRIPTION
This PR adds the `Credis_Client::VERSION` constant. It will need to be bumped for every release.

Closes #135.