### PR TITLE
Fixes connectionStrings parsing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ install:
   - wget http://download.redis.io/releases/redis-5.0.5.tar.gz
   - tar -xzf redis-5.0.5.tar.gz
   - make -s -C redis-5.0.5 -j4
-  - export PATH=$PATH:$PWD/redis-5.0.5/src/
+  - export PATH=$PWD/redis-5.0.5/src/:$PATH
   - |
     if [ ! -z "$PHPUNIT_VERSION" ]; then
       composer require "phpunit/phpunit:${PHPUNIT_VERSION}" --dev --no-update -n

--- a/Client.php
+++ b/Client.php
@@ -423,8 +423,8 @@ class Credis_Client {
                     throw new CredisException('Invalid host format; expected '.$this->scheme.'://host[:port][/persistence_identifier]');
                 }
                 $this->host = $matches[1];
-                $this->port = (int) (isset($matches[3]) ? $matches[3] : 6379);
-                $this->persistent = isset($matches[5]) ? $matches[5] : '';
+                $this->port = (int) (isset($matches[3]) ? $matches[3] : $this->port);
+                $this->persistent = isset($matches[5]) ? $matches[5] : $this->persistent;
             } else {
                 $this->host = $matches[2];
                 $this->port = NULL;

--- a/tests/CredisTest.php
+++ b/tests/CredisTest.php
@@ -632,44 +632,32 @@ class CredisTest extends CredisTestCommon
 
   public function testConnectionStrings()
   {
-      $this->credis->close();
       $this->credis = new Credis_Client('tcp://'.$this->redisConfig[0]['host'] . ':' . $this->redisConfig[0]['port']);
-      if ($this->useStandalone) {
-          $this->credis->forceStandalone();
-      }
       $this->assertEquals($this->credis->getHost(),$this->redisConfig[0]['host']);
       $this->assertEquals($this->credis->getPort(),$this->redisConfig[0]['port']);
       $this->credis = new Credis_Client('tcp://'.$this->redisConfig[0]['host']);
-      if ($this->useStandalone) {
-          $this->credis->forceStandalone();
-      }
-      $this->assertEquals($this->credis->getPort(),$this->redisConfig[0]['port']);
+      $this->assertEquals($this->credis->getPort(),6379);
       $this->credis = new Credis_Client('tcp://'.$this->redisConfig[0]['host'] . ':' . $this->redisConfig[0]['port'] . '/abc123');
-      if ($this->useStandalone) {
-          $this->credis->forceStandalone();
-      }
-      $this->assertEquals('abc123',$this->credis->getPersistence());
+      $this->assertEquals($this->credis->getPersistence(),'abc123');
+      $this->credis = new Credis_Client('tcp://'.$this->redisConfig[0]['host'],6380);
+      $this->assertEquals($this->credis->getPort(),6380);
+      $this->credis = new Credis_Client('tcp://'.$this->redisConfig[0]['host'],NULL,NULL,"abc123");
+      $this->assertEquals($this->credis->getPersistence(),'abc123');
   }
 
   public function testConnectionStringsTls()
   {
-      $this->credis->close();
       $this->credis = new Credis_Client('tls://'.$this->redisConfig[0]['host'] . ':' . $this->redisConfig[0]['port']);
-      if ($this->useStandalone) {
-          $this->credis->forceStandalone();
-      }
       $this->assertEquals($this->credis->getHost(),$this->redisConfig[0]['host']);
       $this->assertEquals($this->credis->getPort(),$this->redisConfig[0]['port']);
       $this->credis = new Credis_Client('tls://'.$this->redisConfig[0]['host']);
-      if ($this->useStandalone) {
-          $this->credis->forceStandalone();
-      }
-      $this->assertEquals($this->credis->getPort(),$this->redisConfig[0]['port']);
+      $this->assertEquals($this->credis->getPort(),6379);
       $this->credis = new Credis_Client('tls://'.$this->redisConfig[0]['host'] . ':' . $this->redisConfig[0]['port'] . '/abc123');
-      if ($this->useStandalone) {
-          $this->credis->forceStandalone();
-      }
-      $this->assertEquals('abc123',$this->credis->getPersistence());
+      $this->assertEquals($this->credis->getPersistence(),'abc123');
+      $this->credis = new Credis_Client('tls://'.$this->redisConfig[0]['host'],6380);
+      $this->assertEquals($this->credis->getPort(),6380);
+      $this->credis = new Credis_Client('tls://'.$this->redisConfig[0]['host'],NULL,NULL,"abc123");
+      $this->assertEquals($this->credis->getPersistence(),'abc123');
   }
 
   /**


### PR DESCRIPTION
- make downloaded redis-server PATH priority higher then built-in one
- Fixes port always be 6379 even no port specified in host string and specified the port number other then 6379 in constructor
- Fixes persistent too
- Added test cases
