### PR TITLE
Fixes #140: Update test suites

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,31 +8,32 @@ matrix:
         - PHPUNIT_VERSION=^5.7
     - php: 7.0
       env:
-        - PHPREDIS_VERSION=redis-5.0.0
-        - PHPUNIT_VERSION=^6.4
+        - PHPREDIS_VERSION=redis-5.3.0
+        - PHPUNIT_VERSION=^6.5
     - php: 7.1
       env:
-        - PHPREDIS_VERSION=redis-5.0.0
-        - PHPUNIT_VERSION=^6.4
+        - PHPREDIS_VERSION=redis-5.3.0
+        - PHPUNIT_VERSION=^7.5
     - php: 7.2
       env:
-        - PHPREDIS_VERSION=redis-5.0.0
+        - PHPREDIS_VERSION=redis-5.3.0
         - PHPUNIT_VERSION=^7.5
     - php: 7.3
       env:
-        - PHPREDIS_VERSION=redis-5.0.0
+        - PHPREDIS_VERSION=redis-5.3.0
         - PHPUNIT_VERSION=^7.5
     - php: 7.4
       env:
-        - PHPREDIS_VERSION=redis-5.0.0
+        - PHPREDIS_VERSION=redis-5.3.0
         - PHPUNIT_VERSION=^7.5
 
 install:
   - yes '' | pecl install -f $PHPREDIS_VERSION
-  - wget http://download.redis.io/releases/redis-5.0.5.tar.gz
-  - tar -xzf redis-5.0.5.tar.gz
-  - make -s -C redis-5.0.5 -j4
-  - export PATH=$PATH:$PWD/redis-5.0.5/src/
+  - wget http://download.redis.io/releases/redis-6.0.8.tar.gz
+  - tar -xzf redis-6.0.8.tar.gz
+  - export BUILD_TLS=yes
+  - make -s -C redis-6.0.8 -j4
+  - export PATH=$PWD/redis-6.0.8/src/:$PATH
   - |
     if [ ! -z "$PHPUNIT_VERSION" ]; then
       composer require "phpunit/phpunit:${PHPUNIT_VERSION}" --dev --no-update -n

--- a/Client.php
+++ b/Client.php
@@ -326,8 +326,8 @@ class Credis_Client {
         $this->authPassword = $password;
         $this->selectedDb = (int)$db;
         $this->convertHost();
-        if ($this->scheme == 'tls') {
-            // PHP Redis extension doesn't work with TLS
+        // PHP Redis extension support TLS since 5.3.0
+        if ($this->scheme == 'tls' && !$this->standalone && version_compare(phpversion('redis'),'5.3.0','<')){
             $this->standalone = true;
         }
     }
@@ -1231,6 +1231,10 @@ class Credis_Client {
                       }
                     }
                     break;
+                case 'auth':
+                    if (is_bool($response) && $response === true){
+                        $this->redis->clearLastError();
+                    }
                 default:
                     $error = $this->redis->getLastError();
                     $this->redis->clearLastError();

--- a/testenv/docker-compose.yml
+++ b/testenv/docker-compose.yml
@@ -1,11 +1,6 @@
 version: '2'
 services:
 
-  php-55:
-    build: env/php-5.5/
-    volumes:
-      - ../:/src/
-
   php-56:
     build: env/php-5.6/
     volumes:
@@ -28,5 +23,10 @@ services:
 
   php-73:
     build: env/php-7.3/
+    volumes:
+      - ../:/src/
+  
+  php-74:
+    build: env/php-7.4/
     volumes:
       - ../:/src/

--- a/testenv/env/php-5.6/Dockerfile
+++ b/testenv/env/php-5.6/Dockerfile
@@ -10,7 +10,7 @@ RUN wget https://phar.phpunit.de/phpunit-${phpunit_verison}.phar && \
     mv phpunit-${phpunit_verison}.phar /usr/local/bin/phpunit
 
 # install php extension
-RUN yes '' | pecl install -f redis && \
+RUN yes '' | pecl install -f redis-4.3.0 && \
     docker-php-ext-enable redis
 
 # install redis server

--- a/testenv/env/php-7.0/Dockerfile
+++ b/testenv/env/php-7.0/Dockerfile
@@ -1,9 +1,9 @@
 FROM php:7.0
-ENV phpunit_verison 6.4
-ENV redis_version 4.0.11
+ENV phpunit_verison 6.5
+ENV redis_version 6.0.8
 
 RUN apt-get update && \
-    apt-get install -y wget
+    apt-get install -y wget libssl-dev
 
 RUN wget https://phar.phpunit.de/phpunit-${phpunit_verison}.phar && \
     chmod +x phpunit-${phpunit_verison}.phar && \
@@ -16,6 +16,7 @@ RUN yes '' | pecl install -f redis && \
 # install redis server
 RUN wget http://download.redis.io/releases/redis-${redis_version}.tar.gz && \
     tar -xzf redis-${redis_version}.tar.gz && \
+    export BUILD_TLS=yes && \
     make -s -C redis-${redis_version} -j
 
 CMD PATH=$PATH:/usr/local/bin/:/redis-${redis_version}/src/ && \

--- a/testenv/env/php-7.1/Dockerfile
+++ b/testenv/env/php-7.1/Dockerfile
@@ -1,9 +1,9 @@
 FROM php:7.1
-ENV phpunit_verison 6.4
-ENV redis_version 4.0.11
+ENV phpunit_verison 7.5
+ENV redis_version 6.0.8
 
 RUN apt-get update && \
-    apt-get install -y wget
+    apt-get install -y wget libssl-dev
 
 RUN wget https://phar.phpunit.de/phpunit-${phpunit_verison}.phar && \
     chmod +x phpunit-${phpunit_verison}.phar && \
@@ -16,6 +16,7 @@ RUN yes '' | pecl install -f redis && \
 # install redis server
 RUN wget http://download.redis.io/releases/redis-${redis_version}.tar.gz && \
     tar -xzf redis-${redis_version}.tar.gz && \
+    export BUILD_TLS=yes && \
     make -s -C redis-${redis_version} -j
 
 CMD PATH=$PATH:/usr/local/bin/:/redis-${redis_version}/src/ && \

--- a/testenv/env/php-7.2/Dockerfile
+++ b/testenv/env/php-7.2/Dockerfile
@@ -1,9 +1,9 @@
 FROM php:7.2
 ENV phpunit_verison 7.5
-ENV redis_version 4.0.11
+ENV redis_version 6.0.8
 
 RUN apt-get update && \
-    apt-get install -y wget
+    apt-get install -y wget libssl-dev
 
 RUN wget https://phar.phpunit.de/phpunit-${phpunit_verison}.phar && \
     chmod +x phpunit-${phpunit_verison}.phar && \
@@ -16,6 +16,7 @@ RUN yes '' | pecl install -f redis && \
 # install redis server
 RUN wget http://download.redis.io/releases/redis-${redis_version}.tar.gz && \
     tar -xzf redis-${redis_version}.tar.gz && \
+    export BUILD_TLS=yes && \
     make -s -C redis-${redis_version} -j
 
 CMD PATH=$PATH:/usr/local/bin/:/redis-${redis_version}/src/ && \

--- a/testenv/env/php-7.3/Dockerfile
+++ b/testenv/env/php-7.3/Dockerfile
@@ -1,9 +1,9 @@
 FROM php:7.3
 ENV phpunit_verison 7.5
-ENV redis_version 4.0.11
+ENV redis_version 6.0.8
 
 RUN apt-get update && \
-    apt-get install -y wget
+    apt-get install -y wget libssl-dev
 
 RUN wget https://phar.phpunit.de/phpunit-${phpunit_verison}.phar && \
     chmod +x phpunit-${phpunit_verison}.phar && \
@@ -16,6 +16,7 @@ RUN yes '' | pecl install -f redis && \
 # install redis server
 RUN wget http://download.redis.io/releases/redis-${redis_version}.tar.gz && \
     tar -xzf redis-${redis_version}.tar.gz && \
+    export BUILD_TLS=yes && \
     make -s -C redis-${redis_version} -j
 
 CMD PATH=$PATH:/usr/local/bin/:/redis-${redis_version}/src/ && \

--- a/testenv/env/php-7.4/Dockerfile
+++ b/testenv/env/php-7.4/Dockerfile
@@ -1,9 +1,9 @@
-FROM php:5.5
-ENV phpunit_verison 4.8
-ENV redis_version 4.0.11
+FROM php:7.4
+ENV phpunit_verison 7.5
+ENV redis_version 6.0.8
 
 RUN apt-get update && \
-    apt-get install -y wget
+    apt-get install -y wget libssl-dev
 
 RUN wget https://phar.phpunit.de/phpunit-${phpunit_verison}.phar && \
     chmod +x phpunit-${phpunit_verison}.phar && \
@@ -16,6 +16,7 @@ RUN yes '' | pecl install -f redis && \
 # install redis server
 RUN wget http://download.redis.io/releases/redis-${redis_version}.tar.gz && \
     tar -xzf redis-${redis_version}.tar.gz && \
+    export BUILD_TLS=yes && \
     make -s -C redis-${redis_version} -j
 
 CMD PATH=$PATH:/usr/local/bin/:/redis-${redis_version}/src/ && \

--- a/tests/CredisClusterTest.php
+++ b/tests/CredisClusterTest.php
@@ -106,7 +106,11 @@ class CredisClusterTest extends CredisTestCommon
   }
   public function testDontHashForCodeCoverage()
   {
-    $this->assertInternalType('array',$this->cluster->info());
+    if (method_exists($this,'assertIsArray')){
+        $this->assertIsArray($this->cluster->info());
+    } else {
+        $this->assertInternalType('array',$this->cluster->info());
+    }
   }
   public function testByHash()
   {

--- a/tests/CredisSentinelTest.php
+++ b/tests/CredisSentinelTest.php
@@ -76,7 +76,11 @@ class CredisSentinelTest extends CredisTestCommon
   public function testMasters()
   {
       $masters = $this->sentinel->masters();
-      $this->assertInternalType('array',$masters);
+      if (method_exists($this,'assertIsArray')){
+        $this->assertIsArray($masters);
+      } else {
+        $this->assertInternalType('array',$masters);
+      }
       $this->assertCount(2,$masters);
       $this->assertArrayHasKey(0,$masters);
       $this->assertArrayHasKey(1,$masters);
@@ -95,7 +99,11 @@ class CredisSentinelTest extends CredisTestCommon
   public function testMaster()
   {
       $master = $this->sentinel->master($this->sentinelConfig->clustername);
-      $this->assertInternalType('array',$master);
+      if (method_exists($this,'assertIsArray')){
+        $this->assertIsArray($master);
+      } else {
+        $this->assertInternalType('array',$master);
+      }
       $this->assertArrayHasKey(1,$master);
       $this->assertArrayHasKey(5,$master);
       $this->assertEquals($this->sentinelConfig->clustername,$master[1]);
@@ -107,7 +115,11 @@ class CredisSentinelTest extends CredisTestCommon
   public function testSlaveClient()
   {
       $slaves = $this->sentinel->getSlaveClients($this->sentinelConfig->clustername);
-      $this->assertInternalType('array',$slaves);
+      if (method_exists($this,'assertIsArray')){
+        $this->assertIsArray($slaves);
+      } else {
+        $this->assertInternalType('array',$slaves);
+      }
       $this->assertCount(1,$slaves);
       foreach($slaves as $slave){
           $this->assertInstanceOf('Credis_Client',$slave);
@@ -118,14 +130,22 @@ class CredisSentinelTest extends CredisTestCommon
   public function testSlaves()
   {
       $slaves = $this->sentinel->slaves($this->sentinelConfig->clustername);
-      $this->assertInternalType('array',$slaves);
+      if (method_exists($this,'assertIsArray')){
+        $this->assertIsArray($slaves);
+      } else {
+        $this->assertInternalType('array',$slaves);
+      }
       $this->assertCount(1,$slaves);
       $this->assertArrayHasKey(0,$slaves);
       $this->assertArrayHasKey(5,$slaves[0]);
       $this->assertEquals(6385,$slaves[0][5]);
 
       $slaves = $this->sentinel->slaves('masterdown');
-      $this->assertInternalType('array',$slaves);
+      if (method_exists($this,'assertIsArray')){
+        $this->assertIsArray($slaves);
+      } else {
+        $this->assertInternalType('array',$slaves);
+      }
       $this->assertCount(0,$slaves);
 
       $this->setExpectedExceptionShim('CredisException','No such master with that name');
@@ -165,7 +185,11 @@ class CredisSentinelTest extends CredisTestCommon
   public function testGetMasterAddressByName()
   {
       $address = $this->sentinel->getMasterAddressByName($this->sentinelConfig->clustername);
-      $this->assertInternalType('array',$address);
+      if (method_exists($this,'assertIsArray')){
+        $this->assertIsArray($address);
+      } else {
+        $this->assertInternalType('array',$address);
+      }
       $this->assertCount(2,$address);
       $this->assertArrayHasKey(0,$address);
       $this->assertArrayHasKey(1,$address);
@@ -184,7 +208,7 @@ class CredisSentinelTest extends CredisTestCommon
       $host = 'localhost';
       $port = '123456';
 
-      $client = $this->createMockShim('\Credis_Client');
+      $client = $this->createMock('\Credis_Client');
       $sentinel = new Credis_Sentinel($client);
 
       $client->expects($this->once())->method('getHost')->willReturn($host);

--- a/tests/CredisTest.php
+++ b/tests/CredisTest.php
@@ -578,7 +578,7 @@ class CredisTest extends CredisTestCommon
       }
       catch(CredisException $e)
       {
-          $this->assertStringStartsWith('ERR invalid password', $e->getMessage());
+          $this->assertStringStartsWith('WRONGPASS invalid username-password pair', $e->getMessage());
           $this->credis->close();
       }
       $this->credis = new Credis_Client($this->redisConfig[4]['host'], $this->redisConfig[4]['port'], $this->redisConfig[4]['timeout'], false, 0);
@@ -592,7 +592,6 @@ class CredisTest extends CredisTestCommon
       catch(CredisException $e)
       {
           $this->assertStringStartsWith('NOAUTH Authentication required', $e->getMessage());
-
       }
       try
       {
@@ -600,7 +599,7 @@ class CredisTest extends CredisTestCommon
       }
       catch(CredisException $e)
       {
-          $this->assertStringStartsWith('ERR invalid password', $e->getMessage());
+          $this->assertStringStartsWith('WRONGPASS invalid username-password pair', $e->getMessage());
       }
       $this->assertTrue($this->credis->auth('thepassword'));
       $this->assertTrue($this->credis->set('key','value'));

--- a/tests/CredisTestCommon.php
+++ b/tests/CredisTestCommon.php
@@ -149,23 +149,6 @@ class CredisTestCommon extends \PHPUnit\Framework\TestCase
         }
     }
 
-
-    //
-    /**
-     * php 7.2 compat fix, as directly polyfilling for older PHPUnit causes a function signature compatibility issue
-     * This is due to the defined return type
-     *
-     * Polyfill for older PHPUnit
-     */
-    protected function createMockShim($originalClassName)
-    {
-        if (method_exists($this, 'getMock')) {
-            return $this->getMock($originalClassName);
-        } else {
-            return parent::createMock($originalClassName);
-        }
-    }
-
     /**
      * php 7.2 compat fix, as directly polyfilling for older PHPUnit causes a function signature compatibility issue
      * This is due to the defined return type


### PR DESCRIPTION
Fixes #140 

- Removed PHP 5.5 & Added PHP 7.4
- Update php-redis to 5.3.0
- Update redis-server to 6.0.8
- Fixes AUTH may not cleanup last error
- Fixes AUTH error message changed since Redis v6