### PR TITLE
Force global namespace for functions which are known to be optimizable to bytecode in php

### DIFF
--- a/Client.php
+++ b/Client.php
@@ -20,7 +20,7 @@
  * @package Credis_Client
  */
 
-if( ! defined('CRLF')) define('CRLF', sprintf('%s%s', chr(13), chr(10)));
+if( ! \defined('CRLF')) \define('CRLF', \sprintf('%s%s', \chr(13), \chr(10)));
 
 /**
  * Credis-specific errors, wraps native Redis errors
@@ -33,7 +33,7 @@ class CredisException extends Exception
 
     public function __construct($message, $code = 0, $exception = NULL)
     {
-        if ($exception && get_class($exception) == 'RedisException' && strpos($message,'read error on connection') === 0) {
+        if ($exception && \get_class($exception) == 'RedisException' && \strpos($message,'read error on connection') === 0) {
             $code = CredisException::CODE_DISCONNECTED;
         }
         parent::__construct($message, $code, $exception);
@@ -539,7 +539,7 @@ class Credis_Client {
                 $timeout = $timeout <= 0 ? 315360000 : $timeout; // Ten-year timeout
                 stream_set_blocking($this->redis, TRUE);
                 stream_set_timeout($this->redis, (int) floor($timeout), ($timeout - floor($timeout)) * 1000000);
-            } else if (defined('Redis::OPT_READ_TIMEOUT')) {
+            } else if (\defined('Redis::OPT_READ_TIMEOUT')) {
                 // supported in phpredis 2.2.3
                 // a timeout value of -1 means reads will not timeout
                 $timeout = $timeout == 0 ? -1 : $timeout;
@@ -614,7 +614,7 @@ class Credis_Client {
 
         // Initialize command map
         if ($map === NULL) {
-            if (is_array($this->renamedCommands)) {
+            if (\is_array($this->renamedCommands)) {
                 $map = $this->renamedCommands;
             } else {
                 $map = array();
@@ -624,16 +624,16 @@ class Credis_Client {
         // Generate and return cached result
         if ( ! isset($map[$command])) {
             // String means all commands are hashed with salted md5
-            if (is_string($this->renamedCommands)) {
+            if (\is_string($this->renamedCommands)) {
                 $map[$command] = md5($this->renamedCommands.$command);
             }
             // Would already be set in $map if it was intended to be renamed
-            else if (is_array($this->renamedCommands)) {
+            else if (\is_array($this->renamedCommands)) {
                 return $command;
             }
             // User-supplied function
-            else if (is_callable($this->renamedCommands)) {
-                $map[$command] = call_user_func($this->renamedCommands, $command);
+            else if (\is_callable($this->renamedCommands)) {
+                $map[$command] = \call_user_func($this->renamedCommands, $command);
             }
         }
         return $map[$command];
@@ -667,7 +667,7 @@ class Credis_Client {
      */
     public function pUnsubscribe()
     {
-    	list($command, $channel, $subscribedChannels) = $this->__call('punsubscribe', func_get_args());
+    	list($command, $channel, $subscribedChannels) = $this->__call('punsubscribe', \func_get_args());
     	$this->subscribed = $subscribedChannels > 0;
     	return array($command, $channel, $subscribedChannels);
     }
@@ -732,7 +732,7 @@ class Credis_Client {
         }
 
         // Standalone mode: use infinite loop to subscribe until timeout
-        $patternCount = is_array($patterns) ? count($patterns) : 1;
+        $patternCount = \is_array($patterns) ? \count($patterns) : 1;
         while ($patternCount--) {
             if (isset($status)) {
                 list($command, $pattern, $status) = $this->read_reply();
@@ -760,7 +760,7 @@ class Credis_Client {
      */
     public function unsubscribe()
     {
-    	list($command, $channel, $subscribedChannels) = $this->__call('unsubscribe', func_get_args());
+    	list($command, $channel, $subscribedChannels) = $this->__call('unsubscribe', \func_get_args());
     	$this->subscribed = $subscribedChannels > 0;
     	return array($command, $channel, $subscribedChannels);
     }
@@ -778,7 +778,7 @@ class Credis_Client {
         }
 
         // Standalone mode: use infinite loop to subscribe until timeout
-        $channelCount = is_array($channels) ? count($channels) : 1;
+        $channelCount = \is_array($channels) ? \count($channels) : 1;
         while ($channelCount--) {
             if (isset($status)) {
                 list($command, $channel, $status) = $this->read_reply();
@@ -823,18 +823,18 @@ class Credis_Client {
             switch ($name) {
                 case 'eval':
                 case 'evalsha':
-                    $script = array_shift($args);
-                    $keys = (array) array_shift($args);
-                    $eArgs = (array) array_shift($args);
-                    $args = array($script, count($keys), $keys, $eArgs);
+                    $script = \array_shift($args);
+                    $keys = (array) \array_shift($args);
+                    $eArgs = (array) \array_shift($args);
+                    $args = array($script, \count($keys), $keys, $eArgs);
                     break;
                 case 'zinterstore':
                 case 'zunionstore':
-                    $dest = array_shift($args);
-                    $keys = (array) array_shift($args);
-                    $weights = array_shift($args);
-                    $aggregate = array_shift($args);
-                    $args = array($dest, count($keys), $keys);
+                    $dest = \array_shift($args);
+                    $keys = (array) \array_shift($args);
+                    $weights = \array_shift($args);
+                    $aggregate = \array_shift($args);
+                    $args = array($dest, \count($keys), $keys);
                     if ($weights) {
                         $args[] = (array) $weights;
                     }
@@ -845,15 +845,15 @@ class Credis_Client {
                 case 'set':
                     // The php redis module has different behaviour with ttl
                     // https://github.com/phpredis/phpredis#set
-                    if (count($args) === 3 && is_int($args[2])) {
+                    if (\count($args) === 3 && \is_int($args[2])) {
                         $args = array($args[0], $args[1], array('EX', $args[2]));
-                    } elseif (count($args) === 3 && is_array($args[2])) {
+                    } elseif (\count($args) === 3 && \is_array($args[2])) {
                         $tmp_args = $args;
                         $args = array($tmp_args[0], $tmp_args[1]);
                         foreach ($tmp_args[2] as $k=>$v) {
-                            if (is_string($k)) {
+                            if (\is_string($k)) {
                                 $args[] = array($k,$v);
-                            } elseif (is_int($k)) {
+                            } elseif (\is_int($k)) {
                                 $args[] = $v;
                             }
                         }
@@ -904,13 +904,13 @@ class Credis_Client {
                 case 'zrevrangebyscore':
                 case 'zrange':
                 case 'zrevrange':
-                    if (isset($args[3]) && is_array($args[3])) {
+                    if (isset($args[3]) && \is_array($args[3])) {
                         // map options
                         $cArgs = array();
                         if (!empty($args[3]['withscores'])) {
                             $cArgs[] = 'withscores';
                         }
-                        if (($name == 'zrangebyscore' || $name == 'zrevrangebyscore') && array_key_exists('limit', $args[3])) {
+                        if (($name == 'zrangebyscore' || $name == 'zrevrangebyscore') && \array_key_exists('limit', $args[3])) {
                             $cArgs[] = array('limit' => $args[3]['limit']);
                         }
                         $args[3] = $cArgs;
@@ -918,13 +918,13 @@ class Credis_Client {
                     }
                     break;
                 case 'mget':
-                    if (isset($args[0]) && is_array($args[0]))
+                    if (isset($args[0]) && \is_array($args[0]))
                     {
-                        $args = array_values($args[0]);
+                        $args = \array_values($args[0]);
                     }
                     break;
                 case 'hmset':
-                    if (isset($args[1]) && is_array($args[1]))
+                    if (isset($args[1]) && \is_array($args[1]))
                     {
                         $cArgs = array();
                         foreach($args[1] as $id => $value)
@@ -1073,7 +1073,7 @@ class Credis_Client {
                    break;
                 case 'zrange':
                 case 'zrevrange':
-                    if (isset($args[3]) && is_array($args[3]))
+                    if (isset($args[3]) && \is_array($args[3]))
                     {
                         $cArgs = $args[3];
                         $args[3] = !empty($cArgs['withscores']);
@@ -1096,7 +1096,7 @@ class Credis_Client {
                     $args = $cArgs;
                     break;
                 case 'mget':
-                    if(isset($args[0]) && ! is_array($args[0])) {
+                    if(isset($args[0]) && ! \is_array($args[0])) {
                         $args = array($args);
                     }
                     break;
@@ -1105,21 +1105,21 @@ class Credis_Client {
                     break;
                 case 'eval':
                 case 'evalsha':
-                    if (isset($args[1]) && is_array($args[1])) {
+                    if (isset($args[1]) && \is_array($args[1])) {
                         $cKeys = $args[1];
-                    } elseif (isset($args[1]) && is_string($args[1])) {
+                    } elseif (isset($args[1]) && \is_string($args[1])) {
                         $cKeys = array($args[1]);
                     } else {
                         $cKeys = array();
                     }
-                    if (isset($args[2]) && is_array($args[2])) {
+                    if (isset($args[2]) && \is_array($args[2])) {
                         $cArgs = $args[2];
-                    } elseif (isset($args[2]) && is_string($args[2])) {
+                    } elseif (isset($args[2]) && \is_string($args[2])) {
                         $cArgs = array($args[2]);
                     } else {
                         $cArgs = array();
                     }
-                    $args = array($args[0], array_merge($cKeys, $cArgs), count($cKeys));
+                    $args = array($args[0], \array_merge($cKeys, $cArgs), \count($cKeys));
                     break;
                 case 'subscribe':
                 case 'psubscribe':
@@ -1143,7 +1143,7 @@ class Credis_Client {
                         return $this;
                     } else {
                         $this->isMulti = TRUE;
-                        $this->redisMulti = call_user_func_array(array($this->redis, $name), $args);
+                        $this->redisMulti = \call_user_func_array(array($this->redis, $name), $args);
                         return $this;
                     }
                 }
@@ -1162,19 +1162,19 @@ class Credis_Client {
 
                 // Multi and pipeline return self for chaining
                 if($this->isMulti) {
-                    call_user_func_array(array($this->redisMulti, $name), $args);
+                    \call_user_func_array(array($this->redisMulti, $name), $args);
                     return $this;
                 }
 
                 // Send request, retry one time when using persistent connections on the first request only
                 $this->requests++;
                 try {
-                    $response = call_user_func_array(array($this->redis, $name), $args);
+                    $response = \call_user_func_array(array($this->redis, $name), $args);
                 } catch (RedisException $e) {
                     if ($this->persistent && $this->requests == 1 && $e->getMessage() == 'read error on connection') {
                         $this->close(true);
                         $this->connect();
-                        $response = call_user_func_array(array($this->redis, $name), $args);
+                        $response = \call_user_func_array(array($this->redis, $name), $args);
                     } else {
                         throw $e;
                     }
@@ -1233,7 +1233,7 @@ class Credis_Client {
                     }
                     break;
                 case 'auth':
-                    if (is_bool($response) && $response === true){
+                    if (\is_bool($response) && $response === true){
                         $this->redis->clearLastError();
                     }
                 default:
@@ -1269,10 +1269,10 @@ class Credis_Client {
             }
         }
 
-        $commandLen = strlen($command);
+        $commandLen = \strlen($command);
         $lastFailed = FALSE;
         for ($written = 0; $written < $commandLen; $written += $fwrite) {
-            $fwrite = fwrite($this->redis, substr($command, $written));
+            $fwrite = \fwrite($this->redis, \substr($command, $written));
             if ($fwrite === FALSE || ($fwrite == 0 && $lastFailed)) {
                 $this->close(true);
                 throw new CredisException('Failed to write entire command to stream');
@@ -1340,7 +1340,7 @@ class Credis_Client {
                 break;
             /* Integer reply */
             case ':':
-                $response = intval(substr($reply, 1));
+                $response = \intval(substr($reply, 1));
                 break;
             default:
                 throw new CredisException('Invalid response: '.print_r($reply, TRUE));
@@ -1362,13 +1362,13 @@ class Credis_Client {
                 $keys = $values = array();
                 while ($response)
                 {
-                    $keys[] = array_shift($response);
-                    $values[] = array_shift($response);
+                    $keys[] = \array_shift($response);
+                    $values[] = \array_shift($response);
                 }
-                $response = count($keys) ? array_combine($keys, $values) : array();
+                $response = \count($keys) ? \array_combine($keys, $values) : array();
                 break;
             case 'info':
-                $lines = explode(CRLF, trim($response, CRLF));
+                $lines = explode(CRLF, \trim($response, CRLF));
                 $response = array();
                 foreach ($lines as $line)
                 {
@@ -1387,7 +1387,7 @@ class Credis_Client {
                 }
                 break;
             case 'hmget':
-                if (count($arguments) != count($response))
+                if (\count($arguments) !== \count($response))
                 {
                     throw new CredisException(
                         'hmget arguments and response do not match: ' . print_r($arguments, true) . ' ' . print_r(
@@ -1396,21 +1396,21 @@ class Credis_Client {
                     );
                 }
                 // rehydrate results into key => value form
-                $response = array_combine($arguments, $response);
+                $response = \array_combine($arguments, $response);
                 break;
 
             case 'scan':
             case 'sscan':
-                $arguments[0] = intval(array_shift($response));
+                $arguments[0] = \intval(\array_shift($response));
                 $response = empty($response[0]) ? array() : $response[0];
                 break;
             case 'hscan':
             case 'zscan':
-                $arguments[0] = intval(array_shift($response));
+                $arguments[0] = \intval(\array_shift($response));
                 $response = empty($response[0]) ? array() : $response[0];
-                if (!empty($response) && is_array($response))
+                if (!empty($response) && \is_array($response))
                 {
-                    $count = count($response);
+                    $count = \count($response);
                     $out = array();
                     for ($i = 0; $i < $count; $i += 2)
                     {
@@ -1423,7 +1423,7 @@ class Credis_Client {
             case 'zrevrangebyscore':
             case 'zrange':
             case 'zrevrange':
-                if (in_array('withscores', $arguments, true))
+                if (\in_array('withscores', $arguments, true))
                 {
                     // Map array of values into key=>score list like phpRedis does
                     $item = null;
@@ -1457,12 +1457,12 @@ class Credis_Client {
      */
     private static function _prepare_command($args)
     {
-        return sprintf('*%d%s%s%s', count($args), CRLF, implode(CRLF, array_map(array('self', '_map'), $args)), CRLF);
+        return sprintf('*%d%s%s%s', \count($args), CRLF, implode(CRLF, \array_map(array('self', '_map'), $args)), CRLF);
     }
 
     private static function _map($arg)
     {
-        return sprintf('$%d%s%s', strlen($arg), CRLF, $arg);
+        return sprintf('$%d%s%s', \strlen($arg), CRLF, $arg);
     }
 
     /**
@@ -1479,11 +1479,11 @@ class Credis_Client {
     private static function _flattenArguments(array $arguments, &$out = array())
     {
         foreach ($arguments as $key => $arg) {
-            if (!is_int($key)) {
+            if (!\is_int($key)) {
                 $out[] = $key;
             }
 
-            if (is_array($arg)) {
+            if (\is_array($arg)) {
                 self::_flattenArguments($arg, $out);
             } else {
                 $out[] = $arg;

--- a/Cluster.php
+++ b/Cluster.php
@@ -87,7 +87,7 @@ class Credis_Cluster
     $client = null;
     foreach ($servers as $server)
     {
-      if(is_array($server)){
+      if(\is_array($server)){
           $client = new Credis_Client(
             $server['host'],
             $server['port'],
@@ -116,7 +116,7 @@ class Credis_Cluster
       $this->clients[] = $client;
       for ($replica = 0; $replica <= $this->replicas; $replica++) {
           $md5num = hexdec(substr(md5($client->getHost().':'.$client->getPort().'-'.$replica),0,7));
-          $this->ring[$md5num] = count($this->clients)-1;
+          $this->ring[$md5num] = \count($this->clients)-1;
       }
     }
     ksort($this->ring, SORT_NUMERIC);
@@ -127,13 +127,13 @@ class Credis_Cluster
       'SAVE',      'BGSAVE',  'LASTSAVE', 'SHUTDOWN',
       'INFO',      'MONITOR', 'SLAVEOF'
     ));
-    if($this->masterClient !== null && count($this->clients()) == 0){
+    if($this->masterClient !== null && \count($this->clients()) == 0){
         $this->clients[] = $this->masterClient;
         for ($replica = 0; $replica <= $this->replicas; $replica++) {
-            $md5num = hexdec(substr(md5($this->masterClient->getHost().':'.$this->masterClient->getHost().'-'.$replica),0,7));
-            $this->ring[$md5num] = count($this->clients)-1;
+            $md5num = hexdec(\substr(md5($this->masterClient->getHost().':'.$this->masterClient->getHost().'-'.$replica),0,7));
+            $this->ring[$md5num] = \count($this->clients)-1;
         }
-        $this->nodes = array_keys($this->ring);
+        $this->nodes = \array_keys($this->ring);
     }
   }
 
@@ -154,10 +154,10 @@ class Credis_Cluster
     if(!$writeOnly){
         $this->clients[] = $this->masterClient;
         for ($replica = 0; $replica <= $this->replicas; $replica++) {
-            $md5num = hexdec(substr(md5($this->masterClient->getHost().':'.$this->masterClient->getHost().'-'.$replica),0,7));
-            $this->ring[$md5num] = count($this->clients)-1;
+            $md5num = hexdec(\substr(md5($this->masterClient->getHost().':'.$this->masterClient->getHost().'-'.$replica),0,7));
+            $this->ring[$md5num] = \count($this->clients)-1;
         }
-        $this->nodes = array_keys($this->ring);
+        $this->nodes = \array_keys($this->ring);
     }
     return $this;
   }
@@ -170,7 +170,7 @@ class Credis_Cluster
    */
   public function client($alias)
   {
-    if (is_int($alias) && isset($this->clients[$alias])) {
+    if (\is_int($alias) && isset($this->clients[$alias])) {
       return $this->clients[$alias];
     }
     else if (isset($this->aliases[$alias])) {
@@ -196,11 +196,11 @@ class Credis_Cluster
    */
   public function all()
   {
-    $args = func_get_args();
-    $name = array_shift($args);
+    $args = \func_get_args();
+    $name = \array_shift($args);
     $results = array();
     foreach($this->clients as $client) {
-      $results[] = call_user_func_array([$client, $name], $args);
+      $results[] = \call_user_func_array([$client, $name], $args);
     }
     return $results;
   }
@@ -236,12 +236,12 @@ class Credis_Cluster
   {
     if($this->masterClient !== null && !$this->isReadOnlyCommand($name)){
         $client = $this->masterClient;
-    }elseif (count($this->clients()) == 1 || isset($this->dont_hash[strtoupper($name)]) || !isset($args[0])) {
+    }elseif (\count($this->clients()) == 1 || isset($this->dont_hash[strtoupper($name)]) || !isset($args[0])) {
       $client = $this->clients[0];
     }
     else {
       $hashKey = $args[0];
-      if (is_array($hashKey)) {
+      if (\is_array($hashKey)) {
         $hashKey = join('|', $hashKey);
       }
       $client = $this->byHash($hashKey);
@@ -250,7 +250,7 @@ class Credis_Cluster
     if ($client->getSelectedDb() != $this->selectedDb) {
       $client->select($this->selectedDb);
     }
-    return call_user_func_array([$client, $name], $args);
+    return \call_user_func_array([$client, $name], $args);
   }
 
   /**
@@ -261,9 +261,9 @@ class Credis_Cluster
    */
   public function hash($key)
   {
-    $needle = hexdec(substr(md5($key),0,7));
+    $needle = hexdec(\substr(md5($key),0,7));
     $server = $min = 0;
-    $max = count($this->nodes) - 1;
+    $max = \count($this->nodes) - 1;
     while ($max >= $min) {
       $position = (int) (($min + $max) / 2);
       $server = $this->nodes[$position];
@@ -337,7 +337,7 @@ class Credis_Cluster
           'TIME' => true,
           'SORT' => true,
       );
-      return array_key_exists(strtoupper($command), $readOnlyCommands);
+      return \array_key_exists(strtoupper($command), $readOnlyCommands);
   }
 }
 

--- a/Module.php
+++ b/Module.php
@@ -63,6 +63,6 @@ class Credis_Module
             throw new \LogicException('Module must be set.');
         }
 
-        return call_user_func(array($this->client, sprintf('%s.%s', $this->moduleName, $name)), $args);
+        return \call_user_func(array($this->client, sprintf('%s.%s', $this->moduleName, $name)), $args);
     }
 }

--- a/Sentinel.php
+++ b/Sentinel.php
@@ -226,12 +226,12 @@ class Credis_Sentinel
                     $workingClients[] =  array('host'=>$slave[3],'port'=>$slave[5],'master'=>false,'db'=>$db,'password'=>$this->_password);
                 }
             }
-            if(count($workingClients)>0){
+            if(\count($workingClients)>0){
                 if($selectRandomSlave){
                     if(!$writeOnly){
                         $workingClients[] = array('host'=>$master[3],'port'=>$master[5],'master'=>false,'db'=>$db,'password'=>$this->_password);
                     }
-                    $clients[] = $workingClients[rand(0,count($workingClients)-1)];
+                    $clients[] = $workingClients[\rand(0,\count($workingClients)-1)];
                 } else {
                     $clients = $workingClients;
                 }
@@ -271,8 +271,8 @@ class Credis_Sentinel
      */
     public function __call($name, $args)
     {
-        array_unshift($args,$name);
-        return call_user_func(array($this->_client,'sentinel'),$args);
+        \array_unshift($args,$name);
+        return \call_user_func(array($this->_client,'sentinel'),$args);
     }
 
     /**

--- a/tests/CredisClusterTest.php
+++ b/tests/CredisClusterTest.php
@@ -13,7 +13,7 @@ class CredisClusterTest extends CredisTestCommon
   {
     parent::setUp();
 
-    $clients = array_slice($this->redisConfig,0,4);
+    $clients = \array_slice($this->redisConfig,0,4);
     $this->cluster = new Credis_Cluster($clients,2,$this->useStandalone);
   }
 
@@ -33,30 +33,30 @@ class CredisClusterTest extends CredisTestCommon
   public function testKeyHashing()
   {
       $this->tearDown();
-      $this->cluster = new Credis_Cluster(array_slice($this->redisConfig, 0, 3), 2, $this->useStandalone);
+      $this->cluster = new Credis_Cluster(\array_slice($this->redisConfig, 0, 3), 2, $this->useStandalone);
       $keys = array();
       $lines = explode("\n", file_get_contents("keys.test"));
       foreach ($lines as $line) {
           $pair = explode(':', trim($line));
-          if (count($pair) >= 2) {
+          if (\count($pair) >= 2) {
               $keys[$pair[0]] = $pair[1];
           }
       }
       foreach ($keys as $key => $value) {
           $this->assertTrue($this->cluster->set($key, $value));
       }
-      $this->cluster = new Credis_Cluster(array_slice($this->redisConfig, 0, 4), 2, true, $this->useStandalone);
+      $this->cluster = new Credis_Cluster(\array_slice($this->redisConfig, 0, 4), 2, true, $this->useStandalone);
       $hits = 0;
       foreach ($keys as $key => $value) {
           if ($this->cluster->all('get',$key)) {
               $hits++;
           }
       }
-      $this->assertEquals(count($keys),$hits);
+      $this->assertEquals(\count($keys),$hits);
   }
   public function testAlias()
   {
-      $slicedConfig = array_slice($this->redisConfig, 0, 4);
+      $slicedConfig = \array_slice($this->redisConfig, 0, 4);
       foreach($slicedConfig as $config) {
           $this->assertEquals($config['port'],$this->cluster->client($config['alias'])->getPort());
       }

--- a/tests/CredisTest.php
+++ b/tests/CredisTest.php
@@ -81,14 +81,14 @@ class CredisTest extends CredisTestCommon
         // Array
         $this->assertTrue($this->credis->mSet(array('bar' => 'BAR', 'apple' => 'red')));
         $mGet = $this->credis->mGet(array('foo','bar','empty'));
-        $this->assertTrue(in_array('FOO', $mGet));
-        $this->assertTrue(in_array('BAR', $mGet));
-        $this->assertTrue(in_array('', $mGet));
+        $this->assertTrue(\in_array('FOO', $mGet));
+        $this->assertTrue(\in_array('BAR', $mGet));
+        $this->assertTrue(\in_array('', $mGet));
 
         // Non-array
         $mGet = $this->credis->mGet('foo','bar');
-        $this->assertTrue(in_array('FOO', $mGet));
-        $this->assertTrue(in_array('BAR', $mGet));
+        $this->assertTrue(\in_array('FOO', $mGet));
+        $this->assertTrue(\in_array('BAR', $mGet));
 
         // Delete strings, null response
         $this->assertEquals(2, $this->credis->del('foo','bar'));
@@ -111,8 +111,8 @@ class CredisTest extends CredisTestCommon
 
         // Non-empty set
         $members = $this->credis->sMembers('myset');
-        $this->assertEquals(3, count($members));
-        $this->assertTrue(in_array('Hello', $members));
+        $this->assertEquals(3, \count($members));
+        $this->assertTrue(\in_array('Hello', $members));
 
         // Empty set
         $this->assertEquals(array(), $this->credis->sMembers('noexist'));
@@ -125,110 +125,110 @@ class CredisTest extends CredisTestCommon
         $this->assertEquals(1, $this->credis->zAdd('myset', 10, 'And'));
         $this->assertEquals(1, $this->credis->zAdd('myset', 11, 'Goodbye'));
 
-        $this->assertEquals(4, count($this->credis->zRange('myset', 0, 4)));
-        $this->assertEquals(2, count($this->credis->zRange('myset', 0, 1)));
+        $this->assertEquals(4, \count($this->credis->zRange('myset', 0, 4)));
+        $this->assertEquals(2, \count($this->credis->zRange('myset', 0, 1)));
 
         $range = $this->credis->zRange('myset', 1, 2);
-        $this->assertEquals(2, count($range));
+        $this->assertEquals(2, \count($range));
         $this->assertEquals('World', $range[0]);
         $this->assertEquals('And', $range[1]);
 
         $range = $this->credis->zRange('myset', 1, 2, array('withscores' => true));
-        $this->assertEquals(2, count($range));
-        $this->assertTrue(array_key_exists('World', $range));
+        $this->assertEquals(2, \count($range));
+        $this->assertTrue(\array_key_exists('World', $range));
         $this->assertEquals(2.123, $range['World']);
-        $this->assertTrue(array_key_exists('And', $range));
+        $this->assertTrue(\array_key_exists('And', $range));
         $this->assertEquals(10, $range['And']);
 
         // withscores-option is off
         $range = $this->credis->zRange('myset', 0, 4, array('withscores'));
-        $this->assertEquals(4, count($range));
-        $this->assertEquals(range(0, 3), array_keys($range)); // expecting numeric array without scores
+        $this->assertEquals(4, \count($range));
+        $this->assertEquals(range(0, 3), \array_keys($range)); // expecting numeric array without scores
 
         $range = $this->credis->zRange('myset', 0, 4, array('withscores' => false));
-        $this->assertEquals(4, count($range));
-        $this->assertEquals(range(0, 3), array_keys($range));
+        $this->assertEquals(4, \count($range));
+        $this->assertEquals(range(0, 3), \array_keys($range));
 
-        $this->assertEquals(4, count($this->credis->zRevRange('myset', 0, 4)));
-        $this->assertEquals(2, count($this->credis->zRevRange('myset', 0, 1)));
+        $this->assertEquals(4, \count($this->credis->zRevRange('myset', 0, 4)));
+        $this->assertEquals(2, \count($this->credis->zRevRange('myset', 0, 1)));
 
         $range = $this->credis->zRevRange('myset', 0, 1, array('withscores' => true));
-        $this->assertEquals(2, count($range));
-        $this->assertTrue(array_key_exists('And', $range));
+        $this->assertEquals(2, \count($range));
+        $this->assertTrue(\array_key_exists('And', $range));
         $this->assertEquals(10, $range['And']);
-        $this->assertTrue(array_key_exists('Goodbye', $range));
+        $this->assertTrue(\array_key_exists('Goodbye', $range));
         $this->assertEquals(11, $range['Goodbye']);
 
         // withscores-option is off
         $range = $this->credis->zRevRange('myset', 0, 4, array('withscores'));
-        $this->assertEquals(4, count($range));
-        $this->assertEquals(range(0, 3), array_keys($range)); // expecting numeric array without scores
+        $this->assertEquals(4, \count($range));
+        $this->assertEquals(range(0, 3), \array_keys($range)); // expecting numeric array without scores
 
         $range = $this->credis->zRevRange('myset', 0, 4, array('withscores' => false));
-        $this->assertEquals(4, count($range));
-        $this->assertEquals(range(0, 3), array_keys($range));
+        $this->assertEquals(4, \count($range));
+        $this->assertEquals(range(0, 3), \array_keys($range));
 
-        $this->assertEquals(4, count($this->credis->zRangeByScore('myset', '-inf', '+inf')));
-        $this->assertEquals(2, count($this->credis->zRangeByScore('myset', '1', '9')));
+        $this->assertEquals(4, \count($this->credis->zRangeByScore('myset', '-inf', '+inf')));
+        $this->assertEquals(2, \count($this->credis->zRangeByScore('myset', '1', '9')));
 
         $range = $this->credis->zRangeByScore('myset', '-inf', '+inf', array('limit' => array(1, 2)));
-        $this->assertEquals(2, count($range));
+        $this->assertEquals(2, \count($range));
         $this->assertEquals('World', $range[0]);
         $this->assertEquals('And', $range[1]);
 
         $range = $this->credis->zRangeByScore('myset', '-inf', '+inf', array('withscores' => true, 'limit' => array(1, 2)));
-        $this->assertEquals(2, count($range));
-        $this->assertTrue(array_key_exists('World', $range));
+        $this->assertEquals(2, \count($range));
+        $this->assertTrue(\array_key_exists('World', $range));
         $this->assertEquals(2.123, $range['World']);
-        $this->assertTrue(array_key_exists('And', $range));
+        $this->assertTrue(\array_key_exists('And', $range));
         $this->assertEquals(10, $range['And']);
 
         $range = $this->credis->zRangeByScore('myset', 10, '+inf', array('withscores' => true));
-        $this->assertEquals(2, count($range));
-        $this->assertTrue(array_key_exists('And', $range));
+        $this->assertEquals(2, \count($range));
+        $this->assertTrue(\array_key_exists('And', $range));
         $this->assertEquals(10, $range['And']);
-        $this->assertTrue(array_key_exists('Goodbye', $range));
+        $this->assertTrue(\array_key_exists('Goodbye', $range));
         $this->assertEquals(11, $range['Goodbye']);
 
         // withscores-option is off
         $range = $this->credis->zRangeByScore('myset', '-inf', '+inf', array('withscores'));
-        $this->assertEquals(4, count($range));
-        $this->assertEquals(range(0, 3), array_keys($range)); // expecting numeric array without scores
+        $this->assertEquals(4, \count($range));
+        $this->assertEquals(range(0, 3), \array_keys($range)); // expecting numeric array without scores
 
         $range = $this->credis->zRangeByScore('myset', '-inf', '+inf', array('withscores' => false));
-        $this->assertEquals(4, count($range));
-        $this->assertEquals(range(0, 3), array_keys($range));
+        $this->assertEquals(4, \count($range));
+        $this->assertEquals(range(0, 3), \array_keys($range));
 
-        $this->assertEquals(4, count($this->credis->zRevRangeByScore('myset', '+inf', '-inf')));
-        $this->assertEquals(2, count($this->credis->zRevRangeByScore('myset', '9', '1')));
+        $this->assertEquals(4, \count($this->credis->zRevRangeByScore('myset', '+inf', '-inf')));
+        $this->assertEquals(2, \count($this->credis->zRevRangeByScore('myset', '9', '1')));
 
         $range = $this->credis->zRevRangeByScore('myset', '+inf', '-inf', array('limit' => array(1, 2)));
-        $this->assertEquals(2, count($range));
+        $this->assertEquals(2, \count($range));
         $this->assertEquals('World', $range[1]);
         $this->assertEquals('And', $range[0]);
 
         $range = $this->credis->zRevRangeByScore('myset', '+inf', '-inf', array('withscores' => true, 'limit' => array(1, 2)));
-        $this->assertEquals(2, count($range));
-        $this->assertTrue(array_key_exists('World', $range));
+        $this->assertEquals(2, \count($range));
+        $this->assertTrue(\array_key_exists('World', $range));
         $this->assertEquals(2.123, $range['World']);
-        $this->assertTrue(array_key_exists('And', $range));
+        $this->assertTrue(\array_key_exists('And', $range));
         $this->assertEquals(10, $range['And']);
 
         $range = $this->credis->zRevRangeByScore('myset', '+inf',10, array('withscores' => true));
-        $this->assertEquals(2, count($range));
-        $this->assertTrue(array_key_exists('And', $range));
+        $this->assertEquals(2,\count($range));
+        $this->assertTrue(\array_key_exists('And', $range));
         $this->assertEquals(10, $range['And']);
-        $this->assertTrue(array_key_exists('Goodbye', $range));
+        $this->assertTrue(\array_key_exists('Goodbye', $range));
         $this->assertEquals(11, $range['Goodbye']);
 
         // withscores-option is off
         $range = $this->credis->zRevRangeByScore('myset', '+inf', '-inf', array('withscores'));
-        $this->assertEquals(4, count($range));
-        $this->assertEquals(range(0, 3), array_keys($range)); // expecting numeric array without scores
+        $this->assertEquals(4, \count($range));
+        $this->assertEquals(\range(0, 3), \array_keys($range)); // expecting numeric array without scores
 
         $range = $this->credis->zRevRangeByScore('myset', '+inf', '-inf', array('withscores' => false));
-        $this->assertEquals(4, count($range));
-        $this->assertEquals(range(0, 3), array_keys($range));
+        $this->assertEquals(4, \count($range));
+        $this->assertEquals(\range(0, 3), \array_keys($range));
 
 
         // testing zunionstore (intersection of sorted sets)
@@ -242,26 +242,26 @@ class CredisTest extends CredisTestCommon
 
         $this->credis->zUnionStore('myset3', array('myset1', 'myset2'));
         $range = $this->credis->zRangeByScore('myset3', '-inf', '+inf', array('withscores' => true));
-        $this->assertEquals(4, count($range));
-        $this->assertTrue(array_key_exists('key1', $range));
+        $this->assertEquals(4, \count($range));
+        $this->assertTrue(\array_key_exists('key1', $range));
         $this->assertEquals(25, $range['key1']);
-        $this->assertTrue(array_key_exists('key_not_in_myset1', $range));
+        $this->assertTrue(\array_key_exists('key_not_in_myset1', $range));
         $this->assertEquals(15, $range['key_not_in_myset1']);
 
         // testing zunionstore AGGREGATE option
         $this->credis->zUnionStore('myset4', array('myset1', 'myset2'), array('aggregate' => 'max'));
         $range = $this->credis->zRangeByScore('myset4', '-inf', '+inf', array('withscores' => true));
-        $this->assertEquals(4, count($range));
-        $this->assertTrue(array_key_exists('key1', $range));
+        $this->assertEquals(4, \count($range));
+        $this->assertTrue(\array_key_exists('key1', $range));
         $this->assertEquals(15, $range['key1']);
-        $this->assertTrue(array_key_exists('key2', $range));
+        $this->assertTrue(\array_key_exists('key2', $range));
         $this->assertEquals(15, $range['key2']);
 
         // testing zunionstore WEIGHTS option
         $this->credis->zUnionStore('myset5', array('myset1', 'myset2'), array('weights' => array(2, 4)));
         $range = $this->credis->zRangeByScore('myset5', '-inf', '+inf', array('withscores' => true));
-        $this->assertEquals(4, count($range));
-        $this->assertTrue(array_key_exists('key1', $range));
+        $this->assertEquals(4, \count($range));
+        $this->assertTrue(\array_key_exists('key1', $range));
         $this->assertEquals(80, $range['key1']);
     }
 
@@ -453,7 +453,7 @@ class CredisTest extends CredisTestCommon
                 ->set('a', 3)
                 ->lpop('a')
                 ->exec();
-        $this->assertEquals(2, count($reply));
+        $this->assertEquals(2, \count($reply));
         $this->assertEquals(TRUE, $reply[0]);
         $this->assertFalse($reply[1]);
     }
@@ -503,7 +503,7 @@ class CredisTest extends CredisTestCommon
             });
             $this->fail('pSubscribe should not return.');
         } catch (CredisException $e) {
-            $this->assertEquals($timeout, intval(microtime(true) - $time));
+            $this->assertEquals($timeout, \intval(microtime(true) - $time));
             if ($this->useStandalone) { // phpredis does not distinguish between timed out and disconnected
                 $this->assertEquals($e->getCode(), CredisException::CODE_TIMED_OUT);
             } else {
@@ -524,7 +524,7 @@ class CredisTest extends CredisTestCommon
             });
             $this->fail('subscribe should not return.');
         } catch (CredisException $e) {
-            $this->assertEquals($timeout, intval(microtime(true) - $time));
+            $this->assertEquals($timeout, \intval(microtime(true) - $time));
             if ($this->useStandalone) { // phpredis does not distinguish between timed out and disconnected
                 $this->assertEquals($e->getCode(), CredisException::CODE_TIMED_OUT);
             } else {
@@ -764,7 +764,7 @@ class CredisTest extends CredisTestCommon
             }
         }
         while($iterator);
-        $this->assertEquals(count($seen), 100);
+        $this->assertEquals(\count($seen), 100);
     }
 
   public function testPing()


### PR DESCRIPTION
php has a number of functions which can be optimized to bytecode. But only if they are pulled from the global namespace. 

If these functions are used in a end-user defined namespace, then php checks the current namespace for those functions and then global which defeats this optimization. 

While credis itself doesn't use namespacing, this PR is to reduce false positives when looking for these functions being used in a namespaced php code-base