### PR TITLE
php8.1 compat fix for socket connection strings & phpredis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 vendor
 phpunit.phar
 phpunit_*.log
+/.phpunit.result.cache

--- a/Client.php
+++ b/Client.php
@@ -201,7 +201,7 @@ class Credis_Client {
 
     /**
      * Port on which the Redis server is running
-     * @var integer
+     * @var integer|null
      */
     protected $port;
 
@@ -358,7 +358,7 @@ class Credis_Client {
     }
     /**
      * Return the port of the Redis instance
-     * @return int
+     * @return int|null
      */
     public function getPort()
     {
@@ -474,8 +474,8 @@ class Credis_Client {
             try
             {
                 $result = $this->persistent
-                    ? $this->redis->pconnect($this->host, $this->port, $socketTimeout, $this->persistent)
-                    : $this->redis->connect($this->host, $this->port, $socketTimeout);
+                    ? $this->redis->pconnect($this->host, (int)$this->port, $socketTimeout, $this->persistent)
+                    : $this->redis->connect($this->host, (int)$this->port, $socketTimeout);
             }
             catch(Exception $e)
             {

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,9 @@
 	"require": {
 		"php": ">=5.4.0"
 	},
+	"suggest": {
+		"ext-redis": "Improved performance for communicating with redis"
+	},
 	"autoload": {
 		"classmap": [
 			"Client.php",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 		}
 	],
 	"require": {
-		"php": ">=5.4.0"
+		"php": ">=5.6.0"
 	},
 	"suggest": {
 		"ext-redis": "Improved performance for communicating with redis"

--- a/tests/CredisStandaloneTest.php
+++ b/tests/CredisStandaloneTest.php
@@ -6,19 +6,6 @@ class CredisStandaloneTest extends CredisTest
 {
     protected $useStandalone = TRUE;
 
-  /**
-   * @group UnixSocket
-   */
-  public function testInvalidPersistentConnectionOnUnixSocket()
-  {
-      $this->credis->close();
-      $this->credis = new Credis_Client('unix://'.realpath(__DIR__).'/redis.sock',0,null,'persistent');
-      $this->credis->forceStandalone();
-      //$this->setExpectedException('CredisException','Persistent connections to UNIX sockets are not supported in standalone mode.');
-      $this->credis->connect();
-      $this->assertTrue($this->credis->isConnected());
-  }
-
   public function testPersistentConnectionsOnStandAloneTcpConnection()
   {
       $this->credis->close();

--- a/tests/CredisTest.php
+++ b/tests/CredisTest.php
@@ -679,11 +679,12 @@ class CredisTest extends CredisTestCommon
    */
   public function testConnectionStringsSocket()
   {
-      $this->credis = new Credis_Client(realpath(__DIR__).'/redis.sock',0,null,'persistent');
+      $this->credis = new Credis_Client(realpath(__DIR__).'/redis.sock');
       if ($this->useStandalone) {
           $this->credis->forceStandalone();
       }
       $this->credis->connect();
+      $this->assertTrue($this->credis->isConnected());
       $this->credis->set('key','value');
       $this->assertEquals('value',$this->credis->get('key'));
   }
@@ -708,6 +709,9 @@ class CredisTest extends CredisTestCommon
       }
   }
 
+  /**
+   * @group UnixSocket
+   */
   public function testInvalidUnixSocketConnectionString()
   {
       $this->credis->close();


### PR DESCRIPTION
phpredis connect's port is int and doesn't actually accept nulls, 0 is the documented value for unix connection strings, even for older versions

Should fix #159