### PR TITLE
php 8.2 compatibility update

### DIFF
--- a/Client.php
+++ b/Client.php
@@ -1587,7 +1587,7 @@ class Credis_Client {
      */
     private static function _prepare_command($args)
     {
-        return sprintf('*%d%s%s%s', count($args), CRLF, implode(CRLF, array_map([self::class, '_map'], $args)), CRLF);
+        return sprintf('*%d%s%s%s', count($args), CRLF, implode(CRLF, array_map([static::class, '_map'], $args)), CRLF);
     }
 
     private static function _map($arg)

--- a/Client.php
+++ b/Client.php
@@ -1587,7 +1587,7 @@ class Credis_Client {
      */
     private static function _prepare_command($args)
     {
-        return sprintf('*%d%s%s%s', count($args), CRLF, implode(CRLF, array_map(array('self', '_map'), $args)), CRLF);
+        return sprintf('*%d%s%s%s', count($args), CRLF, implode(CRLF, array_map([self::class, '_map'], $args)), CRLF);
     }
 
     private static function _map($arg)


### PR DESCRIPTION
Switch to php 5.6+ compatible syntax for `_prepare_command` function.