### PR TITLE
Reformat code, update comment of Credis_Client __construct

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,13 +37,26 @@ jobs:
     - name: Setup Redis
       run: sudo add-apt-repository ppa:redislabs/redis -y -u ; sudo apt install redis -y ; sudo systemctl stop redis\* ; redis-cli --version
 
-    - name: Install phpunit
+    - name: Install dependencies
       env:
         PHPUNIT_VERSION: ${{ matrix.phpunit }}
       run: |
         if [ ! -z "$PHPUNIT_VERSION" ]; then
           composer require "phpunit/phpunit:${PHPUNIT_VERSION}" --dev --no-update -n
+          need_install_dev=1
+        fi
+        if php -r 'exit(version_compare(PHP_VERSION, "8.0") >= 0 ? 0 : 1);'; then
+          composer require "friendsofphp/php-cs-fixer:^3.13" --dev --no-update -n
+          need_install_dev=1
+        fi
+        if [ ! -z "$need_install_dev" ]; then
           composer install --dev -n
+        fi
+
+    - name: Run PHP CS Fixer
+      run: |
+        if [ -f ./vendor/bin/php-cs-fixer ]; then
+          ./vendor/bin/php-cs-fixer fix --diff --dry-run
         fi
 
     - name: Report phpredis version

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .idea
+composer.lock
 vendor
 phpunit.phar
 phpunit_*.log
 /.phpunit.result.cache
+/.php-cs-fixer.cache

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,19 @@
+<?php
+/*
+ * This document has been generated with
+ * https://mlocati.github.io/php-cs-fixer-configurator/#version:3.13.2|configurator
+ * you can change this configuration by importing this file.
+ */
+$config = new PhpCsFixer\Config();
+return $config
+    ->setRules([
+        '@PSR12' => true,
+        'visibility_required' => false, // php 5.6 doesn't support "public const ..."
+    ])
+    ->setFinder(PhpCsFixer\Finder::create()
+        ->in(__DIR__)
+        ->name('*.php')
+        ->ignoreDotFiles(true)
+        ->ignoreVCS(true)
+    )
+;

--- a/Client.php
+++ b/Client.php
@@ -32,7 +32,7 @@ class CredisException extends Exception
 
     public function __construct($message, $code = 0, $exception = NULL)
     {
-        if ($exception && get_class($exception) == 'RedisException' && strpos($message,'read error on connection') === 0) {
+        if ($exception && get_class($exception) == 'RedisException' && strpos($message, 'read error on connection') === 0) {
             $code = CredisException::CODE_DISCONNECTED;
         }
         parent::__construct($message, $code, $exception);
@@ -166,16 +166,17 @@ class CredisException extends Exception
  * @method string|int|array|bool|Credis_Client eval(string $script, array $keys = null, array $args = null)
  * @method string|int|array|bool|Credis_Client evalSha(string $script, array $keys = null, array $args = null)
  */
-class Credis_Client {
+class Credis_Client
+{
 
-    const VERSION          = '1.11.4';
+    const VERSION = '1.11.4';
 
-    const TYPE_STRING      = 'string';
-    const TYPE_LIST        = 'list';
-    const TYPE_SET         = 'set';
-    const TYPE_ZSET        = 'zset';
-    const TYPE_HASH        = 'hash';
-    const TYPE_NONE        = 'none';
+    const TYPE_STRING = 'string';
+    const TYPE_LIST = 'list';
+    const TYPE_SET = 'set';
+    const TYPE_ZSET = 'zset';
+    const TYPE_HASH = 'hash';
+    const TYPE_NONE = 'none';
 
     const FREAD_BLOCK_SIZE = 8192;
 
@@ -314,7 +315,7 @@ class Credis_Client {
      */
     protected $subscribed = false;
 
-    /** @var bool  */
+    /** @var bool */
     protected $oldPhpRedis = false;
 
     /** @var array */
@@ -337,13 +338,13 @@ class Credis_Client {
     }
 
     /**
-     * Creates a Redisent connection to the Redis server on host {@link $host} and port {@link $port}.
+     * Creates a connection to the Redis server on host {@link $host} and port {@link $port}.
      * $host may also be a path to a unix socket or a string in the form of tcp://[hostname]:[port] or unix://[path]
      *
      * @param string $host The hostname of the Redis server
      * @param int|null $port The port number of the Redis server
-     * @param float|null $timeout  Timeout period in seconds
-     * @param string $persistent  Flag to establish persistent connection
+     * @param float|null $timeout Timeout period in seconds
+     * @param string $persistent Flag to establish persistent connection
      * @param int $db The selected database of the Redis server
      * @param string|null $password The authentication password of the Redis server
      * @param string|null $username The authentication username of the Redis server
@@ -351,28 +352,28 @@ class Credis_Client {
      */
     public function __construct($host = '127.0.0.1', $port = 6379, $timeout = null, $persistent = '', $db = 0, $password = null, $username = null, array $tlsOptions = null)
     {
-        $this->host = (string) $host;
+        $this->host = (string)$host;
         if ($port !== null) {
-          $this->port = (int) $port;
+            $this->port = (int)$port;
         }
         $this->scheme = null;
         $this->timeout = $timeout;
-        $this->persistent = (string) $persistent;
-        $this->standalone = ! extension_loaded('redis');
+        $this->persistent = (string)$persistent;
+        $this->standalone = !extension_loaded('redis');
         $this->authPassword = $password;
         $this->authUsername = $username;
         $this->selectedDb = (int)$db;
         $this->convertHost();
         if ($tlsOptions) {
-          $this->setTlsOptions($tlsOptions);
+            $this->setTlsOptions($tlsOptions);
         }
         // PHP Redis extension support TLS/ACL AUTH since 5.3.0
-        $this->oldPhpRedis = (bool)version_compare(phpversion('redis'),'5.3.0','<');
+        $this->oldPhpRedis = (bool)version_compare(phpversion('redis'), '5.3.0', '<');
         if ((
-              $this->isTls
-              || $this->authUsername !== null
+                $this->isTls
+                || $this->authUsername !== null
             )
-            && !$this->standalone && $this->oldPhpRedis){
+            && !$this->standalone && $this->oldPhpRedis) {
             $this->standalone = true;
         }
     }
@@ -389,7 +390,7 @@ class Credis_Client {
      */
     public function isSubscribed()
     {
-    	return $this->subscribed;
+        return $this->subscribed;
     }
 
     /**
@@ -400,6 +401,7 @@ class Credis_Client {
     {
         return $this->host;
     }
+
     /**
      * Return the port of the Redis instance
      * @return int|null
@@ -414,7 +416,7 @@ class Credis_Client {
      */
     public function isTls()
     {
-      return $this->isTls;
+        return $this->isTls;
     }
 
     /**
@@ -425,6 +427,7 @@ class Credis_Client {
     {
         return $this->selectedDb;
     }
+
     /**
      * @return string
      */
@@ -432,16 +435,17 @@ class Credis_Client {
     {
         return $this->persistent;
     }
+
     /**
-     * @throws CredisException
      * @return Credis_Client
+     * @throws CredisException
      */
     public function forceStandalone()
     {
         if ($this->standalone) {
             return $this;
         }
-        if($this->connected) {
+        if ($this->connected) {
             throw new CredisException('Cannot force Credis_Client to use standalone PHP driver after a connection has already been established.');
         }
         $this->standalone = TRUE;
@@ -470,34 +474,34 @@ class Credis_Client {
 
     public function setTlsOptions(array $tlsOptions)
     {
-      if($this->connected) {
-        throw new CredisException('Cannot change TLS options after a connection has already been established.');
-      }
-      $this->tlsOptions = $tlsOptions;
+        if ($this->connected) {
+            throw new CredisException('Cannot change TLS options after a connection has already been established.');
+        }
+        $this->tlsOptions = $tlsOptions;
     }
 
     protected function convertHost()
     {
         if (preg_match('#^(tcp|tls|ssl|tlsv\d(?:\.\d)?|unix)://(.+)$#', $this->host, $matches)) {
             $this->isTls = strpos($matches[1], 'tls') === 0 || strpos($matches[1], 'ssl') === 0;
-            if($this->isTls || $matches[1] === 'tcp') {
+            if ($this->isTls || $matches[1] === 'tcp') {
                 $this->scheme = $matches[1];
-                if ( ! preg_match('#^([^:]+)(:([0-9]+))?(/(.+))?$#', $matches[2], $matches)) {
-                    throw new CredisException('Invalid host format; expected '.$this->scheme.'://host[:port][/persistence_identifier]');
+                if (!preg_match('#^([^:]+)(:([0-9]+))?(/(.+))?$#', $matches[2], $matches)) {
+                    throw new CredisException('Invalid host format; expected ' . $this->scheme . '://host[:port][/persistence_identifier]');
                 }
                 $this->host = $matches[1];
-                $this->port = (int) (isset($matches[3]) ? $matches[3] : $this->port);
+                $this->port = (int)(isset($matches[3]) ? $matches[3] : $this->port);
                 $this->persistent = isset($matches[5]) ? $matches[5] : $this->persistent;
             } else {
                 $this->host = $matches[2];
                 $this->port = NULL;
                 $this->scheme = 'unix';
-                if (substr($this->host,0,1) != '/') {
+                if (substr($this->host, 0, 1) != '/') {
                     throw new CredisException('Invalid unix socket format; expected unix:///path/to/redis.sock');
                 }
             }
         }
-        if ($this->port !== NULL && substr($this->host,0,1) == '/') {
+        if ($this->port !== NULL && substr($this->host, 0, 1) == '/') {
             $this->port = NULL;
             $this->scheme = 'unix';
         }
@@ -507,8 +511,8 @@ class Credis_Client {
     }
 
     /**
-     * @throws CredisException
      * @return Credis_Client
+     * @throws CredisException
      */
     public function connect()
     {
@@ -520,11 +524,11 @@ class Credis_Client {
         if ($this->standalone) {
             $flags = STREAM_CLIENT_CONNECT;
             $remote_socket = $this->port === NULL
-                ? $this->scheme.'://'.$this->host
-                : $this->scheme.'://'.$this->host.':'.$this->port;
+                ? $this->scheme . '://' . $this->host
+                : $this->scheme . '://' . $this->host . ':' . $this->port;
             if ($this->persistent && $this->port !== NULL) {
                 // Persistent connections to UNIX sockets are not supported
-                $remote_socket .= '/'.$this->persistent;
+                $remote_socket .= '/' . $this->persistent;
                 $flags = $flags | STREAM_CLIENT_PERSISTENT;
             }
             if ($this->isTls) {
@@ -543,36 +547,29 @@ class Credis_Client {
             if ($result && $this->isTls) {
                 $this->sslMeta = stream_context_get_options($context);
             }
-        }
-        else {
-            if ( ! $this->redis) {
+        } else {
+            if (!$this->redis) {
                 $this->redis = new Redis;
             }
             $socketTimeout = $this->timeout ?: 0.0;
-            try
-            {
-              if ($this->oldPhpRedis)
-              {
-                $result = $this->persistent
-                  ? $this->redis->pconnect($this->host, (int)$this->port, $socketTimeout, $this->persistent)
-                  : $this->redis->connect($this->host, (int)$this->port, $socketTimeout);
-              }
-              else
-              {
-                // 7th argument is non-documented TLS options. But it only exists on the newer versions of phpredis
-                if ($tlsOptions) {
-                  $context = ['stream' => $tlsOptions];
+            try {
+                if ($this->oldPhpRedis) {
+                    $result = $this->persistent
+                        ? $this->redis->pconnect($this->host, (int)$this->port, $socketTimeout, $this->persistent)
+                        : $this->redis->connect($this->host, (int)$this->port, $socketTimeout);
                 } else {
-                  $context = [];
+                    // 7th argument is non-documented TLS options. But it only exists on the newer versions of phpredis
+                    if ($tlsOptions) {
+                        $context = ['stream' => $tlsOptions];
+                    } else {
+                        $context = [];
+                    }
+                    /** @noinspection PhpMethodParametersCountMismatchInspection */
+                    $result = $this->persistent
+                        ? $this->redis->pconnect($this->scheme . '://' . $this->host, (int)$this->port, $socketTimeout, $this->persistent, 0, 0.0, $context)
+                        : $this->redis->connect($this->scheme . '://' . $this->host, (int)$this->port, $socketTimeout, null, 0, 0.0, $context);
                 }
-                /** @noinspection PhpMethodParametersCountMismatchInspection */
-                $result = $this->persistent
-                  ? $this->redis->pconnect($this->scheme.'://'.$this->host, (int)$this->port, $socketTimeout, $this->persistent, 0, 0.0, $context)
-                  : $this->redis->connect($this->scheme.'://'.$this->host, (int)$this->port, $socketTimeout, null, 0, 0.0, $context);
-              }
-            }
-            catch(Exception $e)
-            {
+            } catch (Exception $e) {
                 // Some applications will capture the php error that phpredis can sometimes generate and throw it as an Exception
                 $result = false;
                 $errno = 1;
@@ -581,7 +578,7 @@ class Credis_Client {
         }
 
         // Use recursion for connection retries
-        if ( ! $result) {
+        if (!$result) {
             $this->connectFailures++;
             if ($this->connectFailures <= $this->maxConnectRetries) {
                 return $this->connect();
@@ -591,7 +588,7 @@ class Credis_Client {
             throw new CredisException(sprintf("Connection to Redis%s %s://%s failed after %s failures.%s",
                 $this->standalone ? ' standalone' : '',
                 $this->scheme,
-                $this->host.($this->port ? ':'.$this->port : ''),
+                $this->host . ($this->port ? ':' . $this->port : ''),
                 $failures,
                 (isset($errno) && isset($errstr) ? "Last Error : ({$errno}) {$errstr}" : "")
             ));
@@ -604,14 +601,15 @@ class Credis_Client {
         if ($this->readTimeout) {
             $this->setReadTimeout($this->readTimeout);
         }
-        if($this->authPassword) {
+        if ($this->authPassword) {
             $this->auth($this->authPassword, $this->authUsername);
         }
-        if($this->selectedDb !== 0) {
+        if ($this->selectedDb !== 0) {
             $this->select($this->selectedDb);
         }
         return $this;
     }
+
     /**
      * @return bool
      */
@@ -619,13 +617,14 @@ class Credis_Client {
     {
         return $this->connected;
     }
+
     /**
      * Set the read timeout for the connection. Use 0 to disable timeouts entirely (or use a very long timeout
      * if not supported).
      *
      * @param float $timeout 0 (or -1) for no timeout, otherwise number of seconds
-     * @throws CredisException
      * @return Credis_Client
+     * @throws CredisException
      */
     public function setReadTimeout($timeout)
     {
@@ -637,7 +636,7 @@ class Credis_Client {
             if ($this->standalone) {
                 $timeout = $timeout <= 0 ? 315360000 : $timeout; // Ten-year timeout
                 stream_set_blocking($this->redis, TRUE);
-                stream_set_timeout($this->redis, (int) floor($timeout), ($timeout - floor($timeout)) * 1000000);
+                stream_set_timeout($this->redis, (int)floor($timeout), ($timeout - floor($timeout)) * 1000000);
             } else if (defined('Redis::OPT_READ_TIMEOUT')) {
                 // supported in phpredis 2.2.3
                 // a timeout value of -1 means reads will not timeout
@@ -654,7 +653,7 @@ class Credis_Client {
     public function close($force = FALSE)
     {
         $result = TRUE;
-        if ($this->redis && ($force || $this->connected && ! $this->persistent)) {
+        if ($this->redis && ($force || $this->connected && !$this->persistent)) {
             try {
                 if (is_callable(array($this->redis, 'close'))) {
                     $this->redis->close();
@@ -684,13 +683,13 @@ class Credis_Client {
      */
     public function renameCommand($command, $alias = NULL)
     {
-        if ( ! $this->standalone) {
+        if (!$this->standalone) {
             $this->forceStandalone();
         }
         if ($alias === NULL) {
             $this->renamedCommands = $command;
         } else {
-            if ( ! $this->renamedCommands) {
+            if (!$this->renamedCommands) {
                 $this->renamedCommands = array();
             }
             $this->renamedCommands[$command] = $alias;
@@ -721,16 +720,14 @@ class Credis_Client {
         }
 
         // Generate and return cached result
-        if ( ! isset($map[$command])) {
+        if (!isset($map[$command])) {
             // String means all commands are hashed with salted md5
             if (is_string($this->renamedCommands)) {
-                $map[$command] = md5($this->renamedCommands.$command);
-            }
-            // Would already be set in $map if it was intended to be renamed
+                $map[$command] = md5($this->renamedCommands . $command);
+            } // Would already be set in $map if it was intended to be renamed
             else if (is_array($this->renamedCommands)) {
                 return $command;
-            }
-            // User-supplied function
+            } // User-supplied function
             else if (is_callable($this->renamedCommands)) {
                 $map[$command] = call_user_func($this->renamedCommands, $command);
             }
@@ -747,7 +744,7 @@ class Credis_Client {
     {
         if ($username !== null) {
             $response = $this->__call('auth', array($username, $password));
-            $this->authUsername= $username;
+            $this->authUsername = $username;
         } else {
             $response = $this->__call('auth', array($password));
         }
@@ -762,7 +759,7 @@ class Credis_Client {
     public function select($index)
     {
         $response = $this->__call('select', array($index));
-        $this->selectedDb = (int) $index;
+        $this->selectedDb = (int)$index;
         return $response;
     }
 
@@ -772,9 +769,9 @@ class Credis_Client {
      */
     public function pUnsubscribe()
     {
-    	list($command, $channel, $subscribedChannels) = $this->__call('punsubscribe', func_get_args());
-    	$this->subscribed = $subscribedChannels > 0;
-    	return array($command, $channel, $subscribedChannels);
+        list($command, $channel, $subscribedChannels) = $this->__call('punsubscribe', func_get_args());
+        $this->subscribed = $subscribedChannels > 0;
+        return array($command, $channel, $subscribedChannels);
     }
 
     /**
@@ -789,16 +786,16 @@ class Credis_Client {
     }
 
     /**
-	 * @param int $Iterator
-	 * @param string $field
-	 * @param string $pattern
-	 * @param int $count
-	 * @return bool|array
-	 */
-	public function hscan(&$Iterator, $field, $pattern = null, $count = null)
-	{
-		return $this->__call('hscan', array($field, &$Iterator, $pattern, $count));
-	}
+     * @param int $Iterator
+     * @param string $field
+     * @param string $pattern
+     * @param int $count
+     * @return bool|array
+     */
+    public function hscan(&$Iterator, $field, $pattern = null, $count = null)
+    {
+        return $this->__call('hscan', array($field, &$Iterator, $pattern, $count));
+    }
 
     /**
      * @param int $Iterator
@@ -832,7 +829,7 @@ class Credis_Client {
      */
     public function pSubscribe($patterns, $callback)
     {
-        if ( ! $this->standalone) {
+        if (!$this->standalone) {
             return $this->__call('pSubscribe', array((array)$patterns, $callback));
         }
 
@@ -845,7 +842,7 @@ class Credis_Client {
                 list($command, $pattern, $status) = $this->__call('psubscribe', array($patterns));
             }
             $this->subscribed = $status > 0;
-            if ( ! $status) {
+            if (!$status) {
                 throw new CredisException('Invalid pSubscribe response.');
             }
         }
@@ -865,20 +862,20 @@ class Credis_Client {
      */
     public function unsubscribe()
     {
-    	list($command, $channel, $subscribedChannels) = $this->__call('unsubscribe', func_get_args());
-    	$this->subscribed = $subscribedChannels > 0;
-    	return array($command, $channel, $subscribedChannels);
+        list($command, $channel, $subscribedChannels) = $this->__call('unsubscribe', func_get_args());
+        $this->subscribed = $subscribedChannels > 0;
+        return array($command, $channel, $subscribedChannels);
     }
 
     /**
      * @param string|array $channels
      * @param $callback
-     * @throws CredisException
      * @return $this|array|bool|Credis_Client|mixed|null|string
+     * @throws CredisException
      */
     public function subscribe($channels, $callback)
     {
-        if ( ! $this->standalone) {
+        if (!$this->standalone) {
             return $this->__call('subscribe', array((array)$channels, $callback));
         }
 
@@ -891,7 +888,7 @@ class Credis_Client {
                 list($command, $channel, $status) = $this->__call('subscribe', array($channels));
             }
             $this->subscribed = $status > 0;
-            if ( ! $status) {
+            if (!$status) {
                 throw new CredisException('Invalid subscribe response.');
             }
         }
@@ -911,27 +908,24 @@ class Credis_Client {
      */
     public function ping($name = null)
     {
-      return $this->__call('ping', $name ? array($name) : array());
+        return $this->__call('ping', $name ? array($name) : array());
     }
 
-  /**
-   * @param string $command
-   * @param array $args
-   *
-   * @return array|Credis_Client
-   */
-   public function rawCommand($command, array $args)
-   {
-     if($this->standalone)
-     {
-       return $this->__call($command, $args);
-     }
-     else
-     {
-       \array_unshift($args, $command);
-       return $this->__call('rawCommand', $args);
-     }
-   }
+    /**
+     * @param string $command
+     * @param array $args
+     *
+     * @return array|Credis_Client
+     */
+    public function rawCommand($command, array $args)
+    {
+        if ($this->standalone) {
+            return $this->__call($command, $args);
+        } else {
+            \array_unshift($args, $command);
+            return $this->__call('rawCommand', $args);
+        }
+    }
 
     public function __call($name, $args)
     {
@@ -941,26 +935,25 @@ class Credis_Client {
         $name = strtolower($name);
 
         // Send request via native PHP
-        if($this->standalone)
-        {
+        if ($this->standalone) {
             $trackedArgs = array();
             switch ($name) {
                 case 'eval':
                 case 'evalsha':
                     $script = array_shift($args);
-                    $keys = (array) array_shift($args);
-                    $eArgs = (array) array_shift($args);
+                    $keys = (array)array_shift($args);
+                    $eArgs = (array)array_shift($args);
                     $args = array($script, count($keys), $keys, $eArgs);
                     break;
                 case 'zinterstore':
                 case 'zunionstore':
                     $dest = array_shift($args);
-                    $keys = (array) array_shift($args);
+                    $keys = (array)array_shift($args);
                     $weights = array_shift($args);
                     $aggregate = array_shift($args);
                     $args = array($dest, count($keys), $keys);
                     if ($weights) {
-                        $args[] = (array) $weights;
+                        $args[] = (array)$weights;
                     }
                     if ($aggregate) {
                         $args[] = $aggregate;
@@ -974,9 +967,9 @@ class Credis_Client {
                     } elseif (count($args) === 3 && is_array($args[2])) {
                         $tmp_args = $args;
                         $args = array($tmp_args[0], $tmp_args[1]);
-                        foreach ($tmp_args[2] as $k=>$v) {
+                        foreach ($tmp_args[2] as $k => $v) {
                             if (is_string($k)) {
-                                $args[] = array($k,$v);
+                                $args[] = array($k, $v);
                             } elseif (is_int($k)) {
                                 $args[] = $v;
                             }
@@ -986,18 +979,15 @@ class Credis_Client {
                     break;
                 case 'scan':
                     $trackedArgs = array(&$args[0]);
-                    if (empty($trackedArgs[0]))
-                    {
+                    if (empty($trackedArgs[0])) {
                         $trackedArgs[0] = 0;
                     }
                     $eArgs = array($trackedArgs[0]);
-                    if (!empty($args[1]))
-                    {
+                    if (!empty($args[1])) {
                         $eArgs[] = 'MATCH';
                         $eArgs[] = $args[1];
                     }
-                    if (!empty($args[2]))
-                    {
+                    if (!empty($args[2])) {
                         $eArgs[] = 'COUNT';
                         $eArgs[] = $args[2];
                     }
@@ -1006,24 +996,21 @@ class Credis_Client {
                 case 'sscan':
                 case 'zscan':
                 case 'hscan':
-					$trackedArgs = array(&$args[1]);
-					if (empty($trackedArgs[0]))
-					{
- 						$trackedArgs[0] = 0;
-					}
-					$eArgs = array($args[0],$trackedArgs[0]);
-					if (!empty($args[2]))
-					{
-						$eArgs[] = 'MATCH';
-						$eArgs[] = $args[2];
-					}
-					if (!empty($args[3]))
-					{
-						$eArgs[] = 'COUNT';
-						$eArgs[] = $args[3];
-					}
-					$args = $eArgs;
-					break;
+                    $trackedArgs = array(&$args[1]);
+                    if (empty($trackedArgs[0])) {
+                        $trackedArgs[0] = 0;
+                    }
+                    $eArgs = array($args[0], $trackedArgs[0]);
+                    if (!empty($args[2])) {
+                        $eArgs[] = 'MATCH';
+                        $eArgs[] = $args[2];
+                    }
+                    if (!empty($args[3])) {
+                        $eArgs[] = 'COUNT';
+                        $eArgs[] = $args[3];
+                    }
+                    $args = $eArgs;
+                    break;
                 case 'zrangebyscore':
                 case 'zrevrangebyscore':
                 case 'zrange':
@@ -1042,17 +1029,14 @@ class Credis_Client {
                     }
                     break;
                 case 'mget':
-                    if (isset($args[0]) && is_array($args[0]))
-                    {
+                    if (isset($args[0]) && is_array($args[0])) {
                         $args = array_values($args[0]);
                     }
                     break;
                 case 'hmset':
-                    if (isset($args[1]) && is_array($args[1]))
-                    {
+                    if (isset($args[1]) && is_array($args[1])) {
                         $cArgs = array();
-                        foreach($args[1] as $id => $value)
-                        {
+                        foreach ($args[1] as $id => $value) {
                             $cArgs[] = $id;
                             $cArgs[] = $value;
                         }
@@ -1067,8 +1051,7 @@ class Credis_Client {
                     break;
                 case 'hmget':
                     // hmget needs to track the keys for rehydrating the results
-                    if (isset($args[1]))
-                    {
+                    if (isset($args[1])) {
                         $trackedArgs = $args[1];
                     }
                     break;
@@ -1077,19 +1060,17 @@ class Credis_Client {
             $args = self::_flattenArguments($args);
 
             // In pipeline mode
-            if($this->usePipeline)
-            {
-                if($name === 'pipeline') {
+            if ($this->usePipeline) {
+                if ($name === 'pipeline') {
                     throw new CredisException('A pipeline is already in use and only one pipeline is supported.');
-                }
-                else if($name === 'exec') {
-                    if($this->isMulti) {
+                } else if ($name === 'exec') {
+                    if ($this->isMulti) {
                         $this->commandNames[] = array($name, $trackedArgs);
                         $this->commands .= self::_prepare_command(array($this->getRenamedCommand($name)));
                     }
 
                     // Write request
-                    if($this->commands) {
+                    if ($this->commands) {
                         $this->write_command($this->commands);
                     }
                     $this->commands = NULL;
@@ -1097,24 +1078,20 @@ class Credis_Client {
                     // Read response
                     $queuedResponses = array();
                     $response = array();
-                    foreach($this->commandNames as $command) {
+                    foreach ($this->commandNames as $command) {
                         list($name, $arguments) = $command;
                         $result = $this->read_reply($name, true);
-                        if ($result !== null)
-                        {
+                        if ($result !== null) {
                             $result = $this->decode_reply($name, $result, $arguments);
-                        }
-                        else
-                        {
+                        } else {
                             $queuedResponses[] = $command;
                         }
                         $response[] = $result;
                     }
 
-                    if($this->isMulti) {
+                    if ($this->isMulti) {
                         $response = array_pop($response);
-                        foreach($queuedResponses as $key => $command)
-                        {
+                        foreach ($queuedResponses as $key => $command) {
                             list($name, $arguments) = $command;
                             $response[$key] = $this->decode_reply($name, $response[$key], $arguments);
                         }
@@ -1123,15 +1100,12 @@ class Credis_Client {
                     $this->commandNames = NULL;
                     $this->usePipeline = $this->isMulti = FALSE;
                     return $response;
-                }
-                else if ($name === 'discard')
-                {
+                } else if ($name === 'discard') {
                     $this->commands = NULL;
                     $this->commandNames = NULL;
                     $this->usePipeline = $this->isMulti = FALSE;
-                }
-                else {
-                    if($name === 'multi') {
+                } else {
+                    if ($name === 'multi') {
                         $this->isMulti = TRUE;
                     }
                     array_unshift($args, $this->getRenamedCommand($name));
@@ -1142,8 +1116,7 @@ class Credis_Client {
             }
 
             // Start pipeline mode
-            if($name === 'pipeline')
-            {
+            if ($name === 'pipeline') {
                 $this->usePipeline = TRUE;
                 $this->commandNames = array();
                 $this->commands = '';
@@ -1151,7 +1124,7 @@ class Credis_Client {
             }
 
             // If unwatching, allow reconnect with no error thrown
-            if($name === 'unwatch') {
+            if ($name === 'unwatch') {
                 $this->isWatching = FALSE;
             }
 
@@ -1163,25 +1136,20 @@ class Credis_Client {
             $response = $this->decode_reply($name, $response, $trackedArgs);
 
             // Watch mode disables reconnect so error is thrown
-            if($name == 'watch') {
+            if ($name == 'watch') {
                 $this->isWatching = TRUE;
-            }
-            // Transaction mode
-            else if($this->isMulti && ($name == 'exec' || $name == 'discard')) {
+            } // Transaction mode
+            else if ($this->isMulti && ($name == 'exec' || $name == 'discard')) {
                 $this->isMulti = FALSE;
-            }
-            // Started transaction
-            else if($this->isMulti || $name == 'multi') {
+            } // Started transaction
+            else if ($this->isMulti || $name == 'multi') {
                 $this->isMulti = TRUE;
                 $response = $this;
             }
-        }
-
-        // Send request via phpredis client
-        else
-        {
+        } // Send request via phpredis client
+        else {
             // Tweak arguments
-            switch($name) {
+            switch ($name) {
                 case 'get':   // optimize common cases
                 case 'set':
                 case 'hget':
@@ -1194,11 +1162,10 @@ class Credis_Client {
                 case 'del':
                 case 'zrangebyscore':
                 case 'zrevrangebyscore':
-                   break;
+                    break;
                 case 'zrange':
                 case 'zrevrange':
-                    if (isset($args[3]) && is_array($args[3]))
-                    {
+                    if (isset($args[3]) && is_array($args[3])) {
                         $cArgs = $args[3];
                         $args[3] = !empty($cArgs['withscores']);
                     }
@@ -1209,18 +1176,18 @@ class Credis_Client {
                     $cArgs = array();
                     $cArgs[] = array_shift($args); // destination
                     $cArgs[] = array_shift($args); // keys
-                    if(isset($args[0]) and isset($args[0]['weights'])) {
-                        $cArgs[] = (array) $args[0]['weights'];
+                    if (isset($args[0]) and isset($args[0]['weights'])) {
+                        $cArgs[] = (array)$args[0]['weights'];
                     } else {
                         $cArgs[] = null;
                     }
-                    if(isset($args[0]) and isset($args[0]['aggregate'])) {
+                    if (isset($args[0]) and isset($args[0]['aggregate'])) {
                         $cArgs[] = strtoupper($args[0]['aggregate']);
                     }
                     $args = $cArgs;
                     break;
                 case 'mget':
-                    if(isset($args[0]) && ! is_array($args[0])) {
+                    if (isset($args[0]) && !is_array($args[0])) {
                         $args = array($args);
                     }
                     break;
@@ -1266,16 +1233,15 @@ class Credis_Client {
 
             try {
                 // Proxy pipeline mode to the phpredis library
-                if($name == 'pipeline' || $name == 'multi') {
-                    if($this->isMulti) {
+                if ($name == 'pipeline' || $name == 'multi') {
+                    if ($this->isMulti) {
                         return $this;
                     } else {
                         $this->isMulti = TRUE;
                         $this->redisMulti = call_user_func_array(array($this->redis, $name), $args);
                         return $this;
                     }
-                }
-                else if($name == 'exec' || $name == 'discard') {
+                } else if ($name == 'exec' || $name == 'discard') {
                     $this->isMulti = FALSE;
                     $response = $this->redisMulti->$name();
                     $this->redisMulti = NULL;
@@ -1284,12 +1250,12 @@ class Credis_Client {
                 }
 
                 // Use aliases to be compatible with phpredis wrapper
-                if(isset($this->wrapperMethods[$name])) {
+                if (isset($this->wrapperMethods[$name])) {
                     $name = $this->wrapperMethods[$name];
                 }
 
                 // Multi and pipeline return self for chaining
-                if($this->isMulti) {
+                if ($this->isMulti) {
                     call_user_func_array(array($this->redisMulti, $name), $args);
                     return $this;
                 }
@@ -1308,11 +1274,10 @@ class Credis_Client {
                         throw $e;
                     }
                 }
-            }
-            // Wrap exceptions
-            catch(RedisException $e) {
+            } // Wrap exceptions
+            catch (RedisException $e) {
                 $code = 0;
-                if ( ! ($result = $this->redis->IsConnected())) {
+                if (!($result = $this->redis->IsConnected())) {
                     $this->close(true);
                     $code = CredisException::CODE_DISCONNECTED;
                 }
@@ -1322,16 +1287,15 @@ class Credis_Client {
             #echo "> $name : ".substr(print_r($response, TRUE),0,100)."\n";
 
             // change return values where it is too difficult to minim in standalone mode
-            switch($name)
-            {
+            switch ($name) {
                 case 'type':
                     $typeMap = array(
-                      self::TYPE_NONE,
-                      self::TYPE_STRING,
-                      self::TYPE_SET,
-                      self::TYPE_LIST,
-                      self::TYPE_ZSET,
-                      self::TYPE_HASH,
+                        self::TYPE_NONE,
+                        self::TYPE_STRING,
+                        self::TYPE_SET,
+                        self::TYPE_LIST,
+                        self::TYPE_ZSET,
+                        self::TYPE_HASH,
                     );
                     $response = $typeMap[$response];
                     break;
@@ -1342,7 +1306,7 @@ class Credis_Client {
                 case 'script':
                     $error = $this->redis->getLastError();
                     $this->redis->clearLastError();
-                    if ($error && substr($error,0,8) == 'NOSCRIPT') {
+                    if ($error && substr($error, 0, 8) == 'NOSCRIPT') {
                         $response = NULL;
                     } else if ($error) {
                         throw new CredisException($error);
@@ -1350,19 +1314,19 @@ class Credis_Client {
                     break;
                 case 'exists':
                     // smooth over phpredis-v4 vs earlier difference to match documented credis return results
-                    $response = (int) $response;
+                    $response = (int)$response;
                     break;
                 case 'ping':
                     if ($response) {
-                      if ($response === true) {
-                        $response = isset($args[0]) ? $args[0] : "PONG";
-                      } else if ($response[0] === '+') {
-                        $response = substr($response, 1);
-                      }
+                        if ($response === true) {
+                            $response = isset($args[0]) ? $args[0] : "PONG";
+                        } else if ($response[0] === '+') {
+                            $response = substr($response, 1);
+                        }
                     }
                     break;
                 case 'auth':
-                    if (is_bool($response) && $response === true){
+                    if (is_bool($response) && $response === true) {
                         $this->redis->clearLastError();
                     }
                 default:
@@ -1381,19 +1345,19 @@ class Credis_Client {
     protected function write_command($command)
     {
         // Reconnect on lost connection (Redis server "timeout" exceeded since last command)
-        if(feof($this->redis)) {
+        if (feof($this->redis)) {
             // If a watch or transaction was in progress and connection was lost, throw error rather than reconnect
             // since transaction/watch state will be lost.
-            if(($this->isMulti && ! $this->usePipeline) || $this->isWatching) {
+            if (($this->isMulti && !$this->usePipeline) || $this->isWatching) {
                 $this->close(true);
                 throw new CredisException('Lost connection to Redis server during watch or transaction.');
             }
             $this->close(true);
             $this->connect();
-            if($this->authPassword) {
+            if ($this->authPassword) {
                 $this->auth($this->authPassword);
             }
-            if($this->selectedDb != 0) {
+            if ($this->selectedDb != 0) {
                 $this->select($this->selectedDb);
             }
         }
@@ -1413,7 +1377,7 @@ class Credis_Client {
     protected function read_reply($name = '', $returnQueued = false)
     {
         $reply = fgets($this->redis);
-        if($reply === FALSE) {
+        if ($reply === FALSE) {
             $info = stream_get_meta_data($this->redis);
             $this->close(true);
             if ($info['timed_out']) {
@@ -1428,30 +1392,30 @@ class Credis_Client {
         switch ($replyType) {
             /* Error reply */
             case '-':
-                if($this->isMulti || $this->usePipeline) {
+                if ($this->isMulti || $this->usePipeline) {
                     $response = FALSE;
-                } else if ($name == 'evalsha' && substr($reply,0,9) == '-NOSCRIPT') {
+                } else if ($name == 'evalsha' && substr($reply, 0, 9) == '-NOSCRIPT') {
                     $response = NULL;
                 } else {
-                    throw new CredisException(substr($reply,0,4) == '-ERR' ? 'ERR '.substr($reply, 5) : substr($reply,1));
+                    throw new CredisException(substr($reply, 0, 4) == '-ERR' ? 'ERR ' . substr($reply, 5) : substr($reply, 1));
                 }
                 break;
             /* Inline reply */
             case '+':
                 $response = substr($reply, 1);
-                if($response == 'OK') {
-                  return TRUE;
+                if ($response == 'OK') {
+                    return TRUE;
                 }
-                if($response == 'QUEUED') {
+                if ($response == 'QUEUED') {
                     return $returnQueued ? null : true;
                 }
                 break;
             /* Bulk reply */
             case '$':
                 if ($reply == '$-1') return FALSE;
-                $size = (int) substr($reply, 1);
+                $size = (int)substr($reply, 1);
                 $response = stream_get_contents($this->redis, $size + 2);
-                if( ! $response) {
+                if (!$response) {
                     $this->close(true);
                     throw new CredisException('Error reading reply.');
                 }
@@ -1464,7 +1428,7 @@ class Credis_Client {
 
                 $response = array();
                 for ($i = 0; $i < $count; $i++) {
-                        $response[] = $this->read_reply();
+                    $response[] = $this->read_reply();
                 }
                 break;
             /* Integer reply */
@@ -1472,25 +1436,23 @@ class Credis_Client {
                 $response = intval(substr($reply, 1));
                 break;
             default:
-                throw new CredisException('Invalid response: '.print_r($reply, TRUE));
+                throw new CredisException('Invalid response: ' . print_r($reply, TRUE));
                 break;
         }
 
         return $response;
     }
 
-    protected function decode_reply($name, $response, array &$arguments = array() )
+    protected function decode_reply($name, $response, array &$arguments = array())
     {
         // Smooth over differences between phpredis and standalone response
-        switch ($name)
-        {
+        switch ($name) {
             case '': // Minor optimization for multi-bulk replies
                 break;
             case 'config':
             case 'hgetall':
                 $keys = $values = array();
-                while ($response)
-                {
+                while ($response) {
                     $keys[] = array_shift($response);
                     $values[] = array_shift($response);
                 }
@@ -1499,10 +1461,8 @@ class Credis_Client {
             case 'info':
                 $lines = explode("\r\n", trim($response, "\r\n"));
                 $response = array();
-                foreach ($lines as $line)
-                {
-                    if (!$line || substr($line, 0, 1) == '#')
-                    {
+                foreach ($lines as $line) {
+                    if (!$line || substr($line, 0, 1) == '#') {
                         continue;
                     }
                     list($key, $value) = explode(':', $line, 2);
@@ -1510,14 +1470,12 @@ class Credis_Client {
                 }
                 break;
             case 'ttl':
-                if ($response === -1)
-                {
+                if ($response === -1) {
                     $response = false;
                 }
                 break;
             case 'hmget':
-                if (count($arguments) != count($response))
-                {
+                if (count($arguments) != count($response)) {
                     throw new CredisException(
                         'hmget arguments and response do not match: ' . print_r($arguments, true) . ' ' . print_r(
                             $response, true
@@ -1537,12 +1495,10 @@ class Credis_Client {
             case 'zscan':
                 $arguments[0] = intval(array_shift($response));
                 $response = empty($response[0]) ? array() : $response[0];
-                if (!empty($response) && is_array($response))
-                {
+                if (!empty($response) && is_array($response)) {
                     $count = count($response);
                     $out = array();
-                    for ($i = 0; $i < $count; $i += 2)
-                    {
+                    for ($i = 0; $i < $count; $i += 2) {
                         $out[$response[$i]] = $response[$i + 1];
                     }
                     $response = $out;
@@ -1552,19 +1508,14 @@ class Credis_Client {
             case 'zrevrangebyscore':
             case 'zrange':
             case 'zrevrange':
-                if (in_array('withscores', $arguments, true))
-                {
+                if (in_array('withscores', $arguments, true)) {
                     // Map array of values into key=>score list like phpRedis does
                     $item = null;
                     $out = array();
-                    foreach ($response as $value)
-                    {
-                        if ($item == null)
-                        {
+                    foreach ($response as $value) {
+                        if ($item == null) {
                             $item = $value;
-                        }
-                        else
-                        {
+                        } else {
                             // 2nd value is the score
                             $out[$item] = (float)$value;
                             $item = null;

--- a/Client.php
+++ b/Client.php
@@ -26,18 +26,16 @@
  */
 class CredisException extends Exception
 {
-
     const CODE_TIMED_OUT = 1;
     const CODE_DISCONNECTED = 2;
 
-    public function __construct($message, $code = 0, $exception = NULL)
+    public function __construct($message, $code = 0, $exception = null)
     {
         if ($exception && get_class($exception) == 'RedisException' && strpos($message, 'read error on connection') === 0) {
             $code = CredisException::CODE_DISCONNECTED;
         }
         parent::__construct($message, $code, $exception);
     }
-
 }
 
 /**
@@ -168,17 +166,12 @@ class CredisException extends Exception
  */
 class Credis_Client
 {
-
-    const VERSION = '1.11.4';
-
     const TYPE_STRING = 'string';
     const TYPE_LIST = 'list';
     const TYPE_SET = 'set';
     const TYPE_ZSET = 'zset';
     const TYPE_HASH = 'hash';
     const TYPE_NONE = 'none';
-
-    const FREAD_BLOCK_SIZE = 8192;
 
     /**
      * Socket connection to the Redis server or Redis library instance
@@ -232,12 +225,12 @@ class Credis_Client
     /**
      * @var bool
      */
-    protected $closeOnDestruct = TRUE;
+    protected $closeOnDestruct = true;
 
     /**
      * @var bool
      */
-    protected $connected = FALSE;
+    protected $connected = false;
 
     /**
      * @var bool
@@ -257,7 +250,7 @@ class Credis_Client
     /**
      * @var bool
      */
-    protected $usePipeline = FALSE;
+    protected $usePipeline = false;
 
     /**
      * @var array
@@ -272,12 +265,12 @@ class Credis_Client
     /**
      * @var bool
      */
-    protected $isMulti = FALSE;
+    protected $isMulti = false;
 
     /**
      * @var bool
      */
-    protected $isWatching = FALSE;
+    protected $isWatching = false;
 
     /**
      * @var string|null
@@ -370,10 +363,10 @@ class Credis_Client
         // PHP Redis extension support TLS/ACL AUTH since 5.3.0
         $this->oldPhpRedis = (bool)version_compare(phpversion('redis'), '5.3.0', '<');
         if ((
-                $this->isTls
-                || $this->authUsername !== null
-            )
-            && !$this->standalone && $this->oldPhpRedis) {
+            $this->isTls
+            || $this->authUsername !== null
+        )
+        && !$this->standalone && $this->oldPhpRedis) {
             $this->standalone = true;
         }
     }
@@ -448,7 +441,7 @@ class Credis_Client
         if ($this->connected) {
             throw new CredisException('Cannot force Credis_Client to use standalone PHP driver after a connection has already been established.');
         }
-        $this->standalone = TRUE;
+        $this->standalone = true;
         return $this;
     }
 
@@ -494,15 +487,15 @@ class Credis_Client
                 $this->persistent = isset($matches[5]) ? $matches[5] : $this->persistent;
             } else {
                 $this->host = $matches[2];
-                $this->port = NULL;
+                $this->port = null;
                 $this->scheme = 'unix';
                 if (substr($this->host, 0, 1) != '/') {
                     throw new CredisException('Invalid unix socket format; expected unix:///path/to/redis.sock');
                 }
             }
         }
-        if ($this->port !== NULL && substr($this->host, 0, 1) == '/') {
-            $this->port = NULL;
+        if ($this->port !== null && substr($this->host, 0, 1) == '/') {
+            $this->port = null;
             $this->scheme = 'unix';
         }
         if (!$this->scheme) {
@@ -523,10 +516,10 @@ class Credis_Client
         $tlsOptions = $this->isTls ? $this->tlsOptions : [];
         if ($this->standalone) {
             $flags = STREAM_CLIENT_CONNECT;
-            $remote_socket = $this->port === NULL
+            $remote_socket = $this->port === null
                 ? $this->scheme . '://' . $this->host
                 : $this->scheme . '://' . $this->host . ':' . $this->port;
-            if ($this->persistent && $this->port !== NULL) {
+            if ($this->persistent && $this->port !== null) {
                 // Persistent connections to UNIX sockets are not supported
                 $remote_socket .= '/' . $this->persistent;
                 $flags = $flags | STREAM_CLIENT_PERSISTENT;
@@ -549,7 +542,7 @@ class Credis_Client
             }
         } else {
             if (!$this->redis) {
-                $this->redis = new Redis;
+                $this->redis = new Redis();
             }
             $socketTimeout = $this->timeout ?: 0.0;
             try {
@@ -585,7 +578,8 @@ class Credis_Client
             }
             $failures = $this->connectFailures;
             $this->connectFailures = 0;
-            throw new CredisException(sprintf("Connection to Redis%s %s://%s failed after %s failures.%s",
+            throw new CredisException(sprintf(
+                "Connection to Redis%s %s://%s failed after %s failures.%s",
                 $this->standalone ? ' standalone' : '',
                 $this->scheme,
                 $this->host . ($this->port ? ':' . $this->port : ''),
@@ -595,7 +589,7 @@ class Credis_Client
         }
 
         $this->connectFailures = 0;
-        $this->connected = TRUE;
+        $this->connected = true;
 
         // Set read timeout
         if ($this->readTimeout) {
@@ -635,9 +629,9 @@ class Credis_Client
         if ($this->isConnected()) {
             if ($this->standalone) {
                 $timeout = $timeout <= 0 ? 315360000 : $timeout; // Ten-year timeout
-                stream_set_blocking($this->redis, TRUE);
+                stream_set_blocking($this->redis, true);
                 stream_set_timeout($this->redis, (int)floor($timeout), ($timeout - floor($timeout)) * 1000000);
-            } else if (defined('Redis::OPT_READ_TIMEOUT')) {
+            } elseif (defined('Redis::OPT_READ_TIMEOUT')) {
                 // supported in phpredis 2.2.3
                 // a timeout value of -1 means reads will not timeout
                 $timeout = $timeout == 0 ? -1 : $timeout;
@@ -650,9 +644,9 @@ class Credis_Client
     /**
      * @return bool
      */
-    public function close($force = FALSE)
+    public function close($force = false)
     {
-        $result = TRUE;
+        $result = true;
         if ($this->redis && ($force || $this->connected && !$this->persistent)) {
             try {
                 if (is_callable(array($this->redis, 'close'))) {
@@ -664,7 +658,7 @@ class Credis_Client
             } catch (Exception $e) {
                 ; // Ignore exceptions on close
             }
-            $this->connected = $this->usePipeline = $this->isMulti = $this->isWatching = FALSE;
+            $this->connected = $this->usePipeline = $this->isMulti = $this->isWatching = false;
         }
         return $result;
     }
@@ -681,12 +675,12 @@ class Credis_Client
      * @param string|null $alias
      * @return $this
      */
-    public function renameCommand($command, $alias = NULL)
+    public function renameCommand($command, $alias = null)
     {
         if (!$this->standalone) {
             $this->forceStandalone();
         }
-        if ($alias === NULL) {
+        if ($alias === null) {
             $this->renamedCommands = $command;
         } else {
             if (!$this->renamedCommands) {
@@ -706,12 +700,12 @@ class Credis_Client
         static $map;
 
         // Command renaming not enabled
-        if ($this->renamedCommands === NULL) {
+        if ($this->renamedCommands === null) {
             return $command;
         }
 
         // Initialize command map
-        if ($map === NULL) {
+        if ($map === null) {
             if (is_array($this->renamedCommands)) {
                 $map = $this->renamedCommands;
             } else {
@@ -725,10 +719,10 @@ class Credis_Client
             if (is_string($this->renamedCommands)) {
                 $map[$command] = md5($this->renamedCommands . $command);
             } // Would already be set in $map if it was intended to be renamed
-            else if (is_array($this->renamedCommands)) {
+            elseif (is_array($this->renamedCommands)) {
                 return $command;
             } // User-supplied function
-            else if (is_callable($this->renamedCommands)) {
+            elseif (is_callable($this->renamedCommands)) {
                 $map[$command] = call_user_func($this->renamedCommands, $command);
             }
         }
@@ -1063,7 +1057,7 @@ class Credis_Client
             if ($this->usePipeline) {
                 if ($name === 'pipeline') {
                     throw new CredisException('A pipeline is already in use and only one pipeline is supported.');
-                } else if ($name === 'exec') {
+                } elseif ($name === 'exec') {
                     if ($this->isMulti) {
                         $this->commandNames[] = array($name, $trackedArgs);
                         $this->commands .= self::_prepare_command(array($this->getRenamedCommand($name)));
@@ -1073,7 +1067,7 @@ class Credis_Client
                     if ($this->commands) {
                         $this->write_command($this->commands);
                     }
-                    $this->commands = NULL;
+                    $this->commands = null;
 
                     // Read response
                     $queuedResponses = array();
@@ -1097,16 +1091,16 @@ class Credis_Client
                         }
                     }
 
-                    $this->commandNames = NULL;
-                    $this->usePipeline = $this->isMulti = FALSE;
+                    $this->commandNames = null;
+                    $this->usePipeline = $this->isMulti = false;
                     return $response;
-                } else if ($name === 'discard') {
-                    $this->commands = NULL;
-                    $this->commandNames = NULL;
-                    $this->usePipeline = $this->isMulti = FALSE;
+                } elseif ($name === 'discard') {
+                    $this->commands = null;
+                    $this->commandNames = null;
+                    $this->usePipeline = $this->isMulti = false;
                 } else {
                     if ($name === 'multi') {
-                        $this->isMulti = TRUE;
+                        $this->isMulti = true;
                     }
                     array_unshift($args, $this->getRenamedCommand($name));
                     $this->commandNames[] = array($name, $trackedArgs);
@@ -1117,7 +1111,7 @@ class Credis_Client
 
             // Start pipeline mode
             if ($name === 'pipeline') {
-                $this->usePipeline = TRUE;
+                $this->usePipeline = true;
                 $this->commandNames = array();
                 $this->commands = '';
                 return $this;
@@ -1125,7 +1119,7 @@ class Credis_Client
 
             // If unwatching, allow reconnect with no error thrown
             if ($name === 'unwatch') {
-                $this->isWatching = FALSE;
+                $this->isWatching = false;
             }
 
             // Non-pipeline mode
@@ -1137,13 +1131,13 @@ class Credis_Client
 
             // Watch mode disables reconnect so error is thrown
             if ($name == 'watch') {
-                $this->isWatching = TRUE;
+                $this->isWatching = true;
             } // Transaction mode
-            else if ($this->isMulti && ($name == 'exec' || $name == 'discard')) {
-                $this->isMulti = FALSE;
+            elseif ($this->isMulti && ($name == 'exec' || $name == 'discard')) {
+                $this->isMulti = false;
             } // Started transaction
-            else if ($this->isMulti || $name == 'multi') {
-                $this->isMulti = TRUE;
+            elseif ($this->isMulti || $name == 'multi') {
+                $this->isMulti = true;
                 $response = $this;
             }
         } // Send request via phpredis client
@@ -1237,14 +1231,14 @@ class Credis_Client
                     if ($this->isMulti) {
                         return $this;
                     } else {
-                        $this->isMulti = TRUE;
+                        $this->isMulti = true;
                         $this->redisMulti = call_user_func_array(array($this->redis, $name), $args);
                         return $this;
                     }
-                } else if ($name == 'exec' || $name == 'discard') {
-                    $this->isMulti = FALSE;
+                } elseif ($name == 'exec' || $name == 'discard') {
+                    $this->isMulti = false;
                     $response = $this->redisMulti->$name();
-                    $this->redisMulti = NULL;
+                    $this->redisMulti = null;
                     #echo "> $name : ".substr(print_r($response, TRUE),0,100)."\n";
                     return $response;
                 }
@@ -1300,15 +1294,15 @@ class Credis_Client
                     $response = $typeMap[$response];
                     break;
 
-                // Handle scripting errors
+                    // Handle scripting errors
                 case 'eval':
                 case 'evalsha':
                 case 'script':
                     $error = $this->redis->getLastError();
                     $this->redis->clearLastError();
                     if ($error && substr($error, 0, 8) == 'NOSCRIPT') {
-                        $response = NULL;
-                    } else if ($error) {
+                        $response = null;
+                    } elseif ($error) {
                         throw new CredisException($error);
                     }
                     break;
@@ -1320,7 +1314,7 @@ class Credis_Client
                     if ($response) {
                         if ($response === true) {
                             $response = isset($args[0]) ? $args[0] : "PONG";
-                        } else if ($response[0] === '+') {
+                        } elseif ($response[0] === '+') {
                             $response = substr($response, 1);
                         }
                     }
@@ -1329,6 +1323,7 @@ class Credis_Client
                     if (is_bool($response) && $response === true) {
                         $this->redis->clearLastError();
                     }
+                    // no break
                 default:
                     $error = $this->redis->getLastError();
                     $this->redis->clearLastError();
@@ -1363,10 +1358,10 @@ class Credis_Client
         }
 
         $commandLen = strlen($command);
-        $lastFailed = FALSE;
+        $lastFailed = false;
         for ($written = 0; $written < $commandLen; $written += $fwrite) {
             $fwrite = fwrite($this->redis, substr($command, $written));
-            if ($fwrite === FALSE || ($fwrite == 0 && $lastFailed)) {
+            if ($fwrite === false || ($fwrite == 0 && $lastFailed)) {
                 $this->close(true);
                 throw new CredisException('Failed to write entire command to stream');
             }
@@ -1377,7 +1372,7 @@ class Credis_Client
     protected function read_reply($name = '', $returnQueued = false)
     {
         $reply = fgets($this->redis);
-        if ($reply === FALSE) {
+        if ($reply === false) {
             $info = stream_get_meta_data($this->redis);
             $this->close(true);
             if ($info['timed_out']) {
@@ -1393,26 +1388,28 @@ class Credis_Client
             /* Error reply */
             case '-':
                 if ($this->isMulti || $this->usePipeline) {
-                    $response = FALSE;
-                } else if ($name == 'evalsha' && substr($reply, 0, 9) == '-NOSCRIPT') {
-                    $response = NULL;
+                    $response = false;
+                } elseif ($name == 'evalsha' && substr($reply, 0, 9) == '-NOSCRIPT') {
+                    $response = null;
                 } else {
                     throw new CredisException(substr($reply, 0, 4) == '-ERR' ? 'ERR ' . substr($reply, 5) : substr($reply, 1));
                 }
                 break;
-            /* Inline reply */
+                /* Inline reply */
             case '+':
                 $response = substr($reply, 1);
                 if ($response == 'OK') {
-                    return TRUE;
+                    return true;
                 }
                 if ($response == 'QUEUED') {
                     return $returnQueued ? null : true;
                 }
                 break;
-            /* Bulk reply */
+                /* Bulk reply */
             case '$':
-                if ($reply == '$-1') return FALSE;
+                if ($reply == '$-1') {
+                    return false;
+                }
                 $size = (int)substr($reply, 1);
                 $response = stream_get_contents($this->redis, $size + 2);
                 if (!$response) {
@@ -1421,22 +1418,24 @@ class Credis_Client
                 }
                 $response = substr($response, 0, $size);
                 break;
-            /* Multi-bulk reply */
+                /* Multi-bulk reply */
             case '*':
                 $count = substr($reply, 1);
-                if ($count == '-1') return FALSE;
+                if ($count == '-1') {
+                    return false;
+                }
 
                 $response = array();
                 for ($i = 0; $i < $count; $i++) {
                     $response[] = $this->read_reply();
                 }
                 break;
-            /* Integer reply */
+                /* Integer reply */
             case ':':
                 $response = intval(substr($reply, 1));
                 break;
             default:
-                throw new CredisException('Invalid response: ' . print_r($reply, TRUE));
+                throw new CredisException('Invalid response: ' . print_r($reply, true));
                 break;
         }
 
@@ -1478,7 +1477,8 @@ class Credis_Client
                 if (count($arguments) != count($response)) {
                     throw new CredisException(
                         'hmget arguments and response do not match: ' . print_r($arguments, true) . ' ' . print_r(
-                            $response, true
+                            $response,
+                            true
                         )
                     );
                 }

--- a/Cluster.php
+++ b/Cluster.php
@@ -15,329 +15,324 @@
  */
 class Credis_Cluster
 {
-  /**
-   * Collection of Credis_Client objects attached to Redis servers
-   * @var Credis_Client[]
-   */
-  protected $clients;
-  /**
-   * If a server is set as master, all write commands go to that one
-   * @var Credis_Client
-   */
-  protected $masterClient;
-  /**
-   * Aliases of Credis_Client objects attached to Redis servers, used to route commands to specific servers
-   * @see Credis_Cluster::to
-   * @var array
-   */
-  protected $aliases;
+    /**
+     * Collection of Credis_Client objects attached to Redis servers
+     * @var Credis_Client[]
+     */
+    protected $clients;
+    /**
+     * If a server is set as master, all write commands go to that one
+     * @var Credis_Client
+     */
+    protected $masterClient;
+    /**
+     * Aliases of Credis_Client objects attached to Redis servers, used to route commands to specific servers
+     * @see Credis_Cluster::to
+     * @var array
+     */
+    protected $aliases;
 
-  /**
-   * Hash ring of Redis server nodes
-   * @var array
-   */
-  protected $ring;
+    /**
+     * Hash ring of Redis server nodes
+     * @var array
+     */
+    protected $ring;
 
-  /**
-   * Individual nodes of pointers to Redis servers on the hash ring
-   * @var array
-   */
-  protected $nodes;
+    /**
+     * Individual nodes of pointers to Redis servers on the hash ring
+     * @var array
+     */
+    protected $nodes;
 
-  /**
-   * The commands that are not subject to hashing
-   * @var array
-   * @access protected
-   */
-  protected $dont_hash;
+    /**
+     * The commands that are not subject to hashing
+     * @var array
+     * @access protected
+     */
+    protected $dont_hash;
 
-  /**
-   * Currently working cluster-wide database number.
-   * @var int
-   */
-  protected $selectedDb = 0;
+    /**
+     * Currently working cluster-wide database number.
+     * @var int
+     */
+    protected $selectedDb = 0;
 
-  /**
-   * Creates an interface to a cluster of Redis servers
-   * Each server should be in the format:
-   *  array(
-   *   'host' => hostname,
-   *   'port' => port,
-   *   'db' => db,
-   *   'password' => password,
-   *   'timeout' => timeout,
-   *   'alias' => alias,
-   *   'persistent' => persistence_identifier,
-   *   'master' => master
-   *   'write_only'=> true/false
-   * )
-   *
-   * @param array $servers The Redis servers in the cluster.
-   * @param int $replicas
-   * @param bool $standAlone
-   * @throws CredisException
-   */
-  public function __construct($servers, $replicas = 128, $standAlone = false)
-  {
-    $this->clients = array();
-    $this->masterClient = null;
-    $this->aliases = array();
-    $this->ring = array();
-    $this->replicas = (int)$replicas;
-    $client = null;
-    foreach ($servers as $server)
+    /**
+     * Creates an interface to a cluster of Redis servers
+     * Each server should be in the format:
+     *  array(
+     *   'host' => hostname,
+     *   'port' => port,
+     *   'db' => db,
+     *   'password' => password,
+     *   'timeout' => timeout,
+     *   'alias' => alias,
+     *   'persistent' => persistence_identifier,
+     *   'master' => master
+     *   'write_only'=> true/false
+     * )
+     *
+     * @param array $servers The Redis servers in the cluster.
+     * @param int $replicas
+     * @param bool $standAlone
+     * @throws CredisException
+     */
+    public function __construct($servers, $replicas = 128, $standAlone = false)
     {
-      if(is_array($server)){
-          $client = new Credis_Client(
-            $server['host'],
-            $server['port'],
-            isset($server['timeout']) ? $server['timeout'] : 2.5,
-            isset($server['persistent']) ? $server['persistent'] : '',
-            isset($server['db']) ? $server['db'] : 0,
-            isset($server['password']) ? $server['password'] : null
-          );
-          if (isset($server['alias'])) {
-            $this->aliases[$server['alias']] = $client;
-          }
-          if(isset($server['master']) && $server['master'] === true){
-            $this->masterClient = $client;
-            if(isset($server['write_only']) && $server['write_only'] === true){
-                continue;
+        $this->clients = array();
+        $this->masterClient = null;
+        $this->aliases = array();
+        $this->ring = array();
+        $this->replicas = (int)$replicas;
+        $client = null;
+        foreach ($servers as $server) {
+            if (is_array($server)) {
+                $client = new Credis_Client(
+                    $server['host'],
+                    $server['port'],
+                    isset($server['timeout']) ? $server['timeout'] : 2.5,
+                    isset($server['persistent']) ? $server['persistent'] : '',
+                    isset($server['db']) ? $server['db'] : 0,
+                    isset($server['password']) ? $server['password'] : null
+                );
+                if (isset($server['alias'])) {
+                    $this->aliases[$server['alias']] = $client;
+                }
+                if (isset($server['master']) && $server['master'] === true) {
+                    $this->masterClient = $client;
+                    if (isset($server['write_only']) && $server['write_only'] === true) {
+                        continue;
+                    }
+                }
+            } elseif ($server instanceof Credis_Client) {
+                $client = $server;
+            } else {
+                throw new CredisException('Server should either be an array or an instance of Credis_Client');
             }
-          }
-      } elseif($server instanceof Credis_Client){
-        $client = $server;
-      } else {
-          throw new CredisException('Server should either be an array or an instance of Credis_Client');
-      }
-      if($standAlone) {
-          $client->forceStandalone();
-      }
-      $this->clients[] = $client;
-      for ($replica = 0; $replica <= $this->replicas; $replica++) {
-          $md5num = hexdec(substr(md5($client->getHost().':'.$client->getPort().'-'.$replica),0,7));
-          $this->ring[$md5num] = count($this->clients)-1;
-      }
-    }
-    ksort($this->ring, SORT_NUMERIC);
-    $this->nodes = array_keys($this->ring);
-    $this->dont_hash = array_flip(array(
-      'RANDOMKEY', 'DBSIZE', 'PIPELINE', 'EXEC',
-      'SELECT',    'MOVE',    'FLUSHDB',  'FLUSHALL',
-      'SAVE',      'BGSAVE',  'LASTSAVE', 'SHUTDOWN',
-      'INFO',      'MONITOR', 'SLAVEOF'
-    ));
-    if($this->masterClient !== null && count($this->clients()) == 0){
-        $this->clients[] = $this->masterClient;
-        for ($replica = 0; $replica <= $this->replicas; $replica++) {
-            $md5num = hexdec(substr(md5($this->masterClient->getHost().':'.$this->masterClient->getHost().'-'.$replica),0,7));
-            $this->ring[$md5num] = count($this->clients)-1;
+            if ($standAlone) {
+                $client->forceStandalone();
+            }
+            $this->clients[] = $client;
+            for ($replica = 0; $replica <= $this->replicas; $replica++) {
+                $md5num = hexdec(substr(md5($client->getHost() . ':' . $client->getPort() . '-' . $replica), 0, 7));
+                $this->ring[$md5num] = count($this->clients) - 1;
+            }
         }
+        ksort($this->ring, SORT_NUMERIC);
         $this->nodes = array_keys($this->ring);
-    }
-  }
-
-  /**
-   * @param Credis_Client $masterClient
-   * @param bool $writeOnly
-   * @return Credis_Cluster
-   */
-  public function setMasterClient(Credis_Client $masterClient, $writeOnly=false)
-  {
-    if(!$masterClient instanceof Credis_Client){
-        throw new CredisException('Master client should be an instance of Credis_Client');
-    }
-    $this->masterClient = $masterClient;
-    if (!isset($this->aliases['master'])) {
-        $this->aliases['master'] = $masterClient;
-    }
-    if(!$writeOnly){
-        $this->clients[] = $this->masterClient;
-        for ($replica = 0; $replica <= $this->replicas; $replica++) {
-            $md5num = hexdec(substr(md5($this->masterClient->getHost().':'.$this->masterClient->getHost().'-'.$replica),0,7));
-            $this->ring[$md5num] = count($this->clients)-1;
+        $this->dont_hash = array_flip(array(
+            'RANDOMKEY', 'DBSIZE', 'PIPELINE', 'EXEC',
+            'SELECT', 'MOVE', 'FLUSHDB', 'FLUSHALL',
+            'SAVE', 'BGSAVE', 'LASTSAVE', 'SHUTDOWN',
+            'INFO', 'MONITOR', 'SLAVEOF'
+        ));
+        if ($this->masterClient !== null && count($this->clients()) == 0) {
+            $this->clients[] = $this->masterClient;
+            for ($replica = 0; $replica <= $this->replicas; $replica++) {
+                $md5num = hexdec(substr(md5($this->masterClient->getHost() . ':' . $this->masterClient->getHost() . '-' . $replica), 0, 7));
+                $this->ring[$md5num] = count($this->clients) - 1;
+            }
+            $this->nodes = array_keys($this->ring);
         }
-        $this->nodes = array_keys($this->ring);
     }
-    return $this;
-  }
-  /**
-   * Get a client by index or alias.
-   *
-   * @param string|int $alias
-   * @throws CredisException
-   * @return Credis_Client
-   */
-  public function client($alias)
-  {
-    if (is_int($alias) && isset($this->clients[$alias])) {
-      return $this->clients[$alias];
-    }
-    else if (isset($this->aliases[$alias])) {
-      return $this->aliases[$alias];
-    }
-    throw new CredisException("Client $alias does not exist.");
-  }
 
-  /**
-   * Get an array of all clients
-   *
-   * @return array|Credis_Client[]
-   */
-  public function clients()
-  {
-    return $this->clients;
-  }
-
-  /**
-   * Execute a command on all clients
-   *
-   * @return array
-   */
-  public function all()
-  {
-    $args = func_get_args();
-    $name = array_shift($args);
-    $results = array();
-    foreach($this->clients as $client) {
-      $results[] = call_user_func_array([$client, $name], $args);
+    /**
+     * @param Credis_Client $masterClient
+     * @param bool $writeOnly
+     * @return Credis_Cluster
+     */
+    public function setMasterClient(Credis_Client $masterClient, $writeOnly = false)
+    {
+        if (!$masterClient instanceof Credis_Client) {
+            throw new CredisException('Master client should be an instance of Credis_Client');
+        }
+        $this->masterClient = $masterClient;
+        if (!isset($this->aliases['master'])) {
+            $this->aliases['master'] = $masterClient;
+        }
+        if (!$writeOnly) {
+            $this->clients[] = $this->masterClient;
+            for ($replica = 0; $replica <= $this->replicas; $replica++) {
+                $md5num = hexdec(substr(md5($this->masterClient->getHost() . ':' . $this->masterClient->getHost() . '-' . $replica), 0, 7));
+                $this->ring[$md5num] = count($this->clients) - 1;
+            }
+            $this->nodes = array_keys($this->ring);
+        }
+        return $this;
     }
-    return $results;
-  }
 
-  /**
-   * Get the client that the key would hash to.
-   *
-   * @param string $key
-   * @return \Credis_Client
-   */
-  public function byHash($key)
-  {
-    return $this->clients[$this->hash($key)];
-  }
-
-  /**
-   * @param int $index
-   * @return void
-   */
-  public function select($index)
-  {
-      $this->selectedDb = (int) $index;
-  }
-
-  /**
-   * Execute a Redis command on the cluster with automatic consistent hashing and read/write splitting
-   *
-   * @param string $name
-   * @param array $args
-   * @return mixed
-   */
-  public function __call($name, $args)
-  {
-    if($this->masterClient !== null && !$this->isReadOnlyCommand($name)){
-        $client = $this->masterClient;
-    }elseif (count($this->clients()) == 1 || isset($this->dont_hash[strtoupper($name)]) || !isset($args[0])) {
-      $client = $this->clients[0];
+    /**
+     * Get a client by index or alias.
+     *
+     * @param string|int $alias
+     * @return Credis_Client
+     * @throws CredisException
+     */
+    public function client($alias)
+    {
+        if (is_int($alias) && isset($this->clients[$alias])) {
+            return $this->clients[$alias];
+        } else if (isset($this->aliases[$alias])) {
+            return $this->aliases[$alias];
+        }
+        throw new CredisException("Client $alias does not exist.");
     }
-    else {
-      $hashKey = $args[0];
-      if (is_array($hashKey)) {
-        $hashKey = join('|', $hashKey);
-      }
-      $client = $this->byHash($hashKey);
-    }
-    // Ensure that current client is working on the same database as expected.
-    if ($client->getSelectedDb() != $this->selectedDb) {
-      $client->select($this->selectedDb);
-    }
-    return call_user_func_array([$client, $name], $args);
-  }
 
-  /**
-   * Get client index for a key by searching ring with binary search
-   *
-   * @param string $key The key to hash
-   * @return int The index of the client object associated with the hash of the key
-   */
-  public function hash($key)
-  {
-    $needle = hexdec(substr(md5($key),0,7));
-    $server = $min = 0;
-    $max = count($this->nodes) - 1;
-    while ($max >= $min) {
-      $position = (int) (($min + $max) / 2);
-      $server = $this->nodes[$position];
-      if ($needle < $server) {
-        $max = $position - 1;
-      }
-      else if ($needle > $server) {
-        $min = $position + 1;
-      }
-      else {
-        break;
-      }
+    /**
+     * Get an array of all clients
+     *
+     * @return array|Credis_Client[]
+     */
+    public function clients()
+    {
+        return $this->clients;
     }
-    return $this->ring[$server];
-  }
 
-  public function isReadOnlyCommand($command)
-  {
-      static $readOnlyCommands = array(
-          'DBSIZE' => true,
-          'INFO' => true,
-          'MONITOR' => true,
-          'EXISTS' => true,
-          'TYPE' => true,
-          'KEYS' => true,
-          'SCAN' => true,
-          'RANDOMKEY' => true,
-          'TTL' => true,
-          'GET' => true,
-          'MGET' => true,
-          'SUBSTR' => true,
-          'STRLEN' => true,
-          'GETRANGE' => true,
-          'GETBIT' => true,
-          'LLEN' => true,
-          'LRANGE' => true,
-          'LINDEX' => true,
-          'SCARD' => true,
-          'SISMEMBER' => true,
-          'SINTER' => true,
-          'SUNION' => true,
-          'SDIFF' => true,
-          'SMEMBERS' => true,
-          'SSCAN' => true,
-          'SRANDMEMBER' => true,
-          'ZRANGE' => true,
-          'ZREVRANGE' => true,
-          'ZRANGEBYSCORE' => true,
-          'ZREVRANGEBYSCORE' => true,
-          'ZCARD' => true,
-          'ZSCORE' => true,
-          'ZCOUNT' => true,
-          'ZRANK' => true,
-          'ZREVRANK' => true,
-          'ZSCAN' => true,
-          'HGET' => true,
-          'HMGET' => true,
-          'HEXISTS' => true,
-          'HLEN' => true,
-          'HKEYS' => true,
-          'HVALS' => true,
-          'HGETALL' => true,
-          'HSCAN' => true,
-          'PING' => true,
-          'AUTH' => true,
-          'SELECT' => true,
-          'ECHO' => true,
-          'QUIT' => true,
-          'OBJECT' => true,
-          'BITCOUNT' => true,
-          'TIME' => true,
-          'SORT' => true,
-      );
-      return array_key_exists(strtoupper($command), $readOnlyCommands);
-  }
+    /**
+     * Execute a command on all clients
+     *
+     * @return array
+     */
+    public function all()
+    {
+        $args = func_get_args();
+        $name = array_shift($args);
+        $results = array();
+        foreach ($this->clients as $client) {
+            $results[] = call_user_func_array([$client, $name], $args);
+        }
+        return $results;
+    }
+
+    /**
+     * Get the client that the key would hash to.
+     *
+     * @param string $key
+     * @return \Credis_Client
+     */
+    public function byHash($key)
+    {
+        return $this->clients[$this->hash($key)];
+    }
+
+    /**
+     * @param int $index
+     * @return void
+     */
+    public function select($index)
+    {
+        $this->selectedDb = (int)$index;
+    }
+
+    /**
+     * Execute a Redis command on the cluster with automatic consistent hashing and read/write splitting
+     *
+     * @param string $name
+     * @param array $args
+     * @return mixed
+     */
+    public function __call($name, $args)
+    {
+        if ($this->masterClient !== null && !$this->isReadOnlyCommand($name)) {
+            $client = $this->masterClient;
+        } elseif (count($this->clients()) == 1 || isset($this->dont_hash[strtoupper($name)]) || !isset($args[0])) {
+            $client = $this->clients[0];
+        } else {
+            $hashKey = $args[0];
+            if (is_array($hashKey)) {
+                $hashKey = join('|', $hashKey);
+            }
+            $client = $this->byHash($hashKey);
+        }
+        // Ensure that current client is working on the same database as expected.
+        if ($client->getSelectedDb() != $this->selectedDb) {
+            $client->select($this->selectedDb);
+        }
+        return call_user_func_array([$client, $name], $args);
+    }
+
+    /**
+     * Get client index for a key by searching ring with binary search
+     *
+     * @param string $key The key to hash
+     * @return int The index of the client object associated with the hash of the key
+     */
+    public function hash($key)
+    {
+        $needle = hexdec(substr(md5($key), 0, 7));
+        $server = $min = 0;
+        $max = count($this->nodes) - 1;
+        while ($max >= $min) {
+            $position = (int)(($min + $max) / 2);
+            $server = $this->nodes[$position];
+            if ($needle < $server) {
+                $max = $position - 1;
+            } else if ($needle > $server) {
+                $min = $position + 1;
+            } else {
+                break;
+            }
+        }
+        return $this->ring[$server];
+    }
+
+    public function isReadOnlyCommand($command)
+    {
+        static $readOnlyCommands = array(
+            'DBSIZE' => true,
+            'INFO' => true,
+            'MONITOR' => true,
+            'EXISTS' => true,
+            'TYPE' => true,
+            'KEYS' => true,
+            'SCAN' => true,
+            'RANDOMKEY' => true,
+            'TTL' => true,
+            'GET' => true,
+            'MGET' => true,
+            'SUBSTR' => true,
+            'STRLEN' => true,
+            'GETRANGE' => true,
+            'GETBIT' => true,
+            'LLEN' => true,
+            'LRANGE' => true,
+            'LINDEX' => true,
+            'SCARD' => true,
+            'SISMEMBER' => true,
+            'SINTER' => true,
+            'SUNION' => true,
+            'SDIFF' => true,
+            'SMEMBERS' => true,
+            'SSCAN' => true,
+            'SRANDMEMBER' => true,
+            'ZRANGE' => true,
+            'ZREVRANGE' => true,
+            'ZRANGEBYSCORE' => true,
+            'ZREVRANGEBYSCORE' => true,
+            'ZCARD' => true,
+            'ZSCORE' => true,
+            'ZCOUNT' => true,
+            'ZRANK' => true,
+            'ZREVRANK' => true,
+            'ZSCAN' => true,
+            'HGET' => true,
+            'HMGET' => true,
+            'HEXISTS' => true,
+            'HLEN' => true,
+            'HKEYS' => true,
+            'HVALS' => true,
+            'HGETALL' => true,
+            'HSCAN' => true,
+            'PING' => true,
+            'AUTH' => true,
+            'SELECT' => true,
+            'ECHO' => true,
+            'QUIT' => true,
+            'OBJECT' => true,
+            'BITCOUNT' => true,
+            'TIME' => true,
+            'SORT' => true,
+        );
+        return array_key_exists(strtoupper($command), $readOnlyCommands);
+    }
 }
-

--- a/Cluster.php
+++ b/Cluster.php
@@ -172,7 +172,7 @@ class Credis_Cluster
     {
         if (is_int($alias) && isset($this->clients[$alias])) {
             return $this->clients[$alias];
-        } else if (isset($this->aliases[$alias])) {
+        } elseif (isset($this->aliases[$alias])) {
             return $this->aliases[$alias];
         }
         throw new CredisException("Client $alias does not exist.");
@@ -267,7 +267,7 @@ class Credis_Cluster
             $server = $this->nodes[$position];
             if ($needle < $server) {
                 $max = $position - 1;
-            } else if ($needle > $server) {
+            } elseif ($needle > $server) {
                 $min = $position + 1;
             } else {
                 break;

--- a/Module.php
+++ b/Module.php
@@ -47,7 +47,7 @@ class Credis_Module
      */
     public function setModule($moduleName)
     {
-        $this->moduleName = (string) $moduleName;
+        $this->moduleName = (string)$moduleName;
 
         return $this;
     }

--- a/Sentinel.php
+++ b/Sentinel.php
@@ -78,7 +78,7 @@ class Credis_Sentinel
      */
     protected $_redisVersion = null;
 
-  /**
+    /**
      * Connect with a Sentinel node. Sentinel will do the master and slave discovery
      *
      * @param Credis_Client $client
@@ -88,12 +88,12 @@ class Credis_Sentinel
     public function __construct(Credis_Client $client, $password = NULL, $username = NULL)
     {
         $client->forceStandalone(); // SENTINEL command not currently supported by phpredis
-        $this->_client     = $client;
-        $this->_password   = $password;
-        $this->_username   = $username;
-        $this->_timeout    = NULL;
+        $this->_client = $client;
+        $this->_password = $password;
+        $this->_username = $username;
+        $this->_timeout = NULL;
         $this->_persistent = '';
-        $this->_db         = 0;
+        $this->_db = 0;
     }
 
     /**
@@ -150,8 +150,8 @@ class Credis_Sentinel
      */
     public function setClientUsername($username)
     {
-      $this->_username = $username;
-      return $this;
+        $this->_username = $username;
+        return $this;
     }
 
     /**
@@ -160,19 +160,19 @@ class Credis_Sentinel
      */
     public function setReplicaCommand($replicaCmd)
     {
-      $this->_replicaCmd = $replicaCmd;
-      return $this;
+        $this->_replicaCmd = $replicaCmd;
+        return $this;
     }
 
     public function detectRedisVersion()
     {
-      if ($this->_redisVersion !== null && $this->_replicaCmd !== null) {
-        return;
-      }
-      $serverInfo = $this->info('server');
-      $this->_redisVersion =  $serverInfo['redis_version'];
-      // Redis v7+ renames the replica command to 'replicas' instead of 'slaves'
-      $this->_replicaCmd = version_compare($this->_redisVersion, '7.0.0', '>=') ? 'replicas' : 'slaves';
+        if ($this->_redisVersion !== null && $this->_replicaCmd !== null) {
+            return;
+        }
+        $serverInfo = $this->info('server');
+        $this->_redisVersion = $serverInfo['redis_version'];
+        // Redis v7+ renames the replica command to 'replicas' instead of 'slaves'
+        $this->_replicaCmd = version_compare($this->_redisVersion, '7.0.0', '>=') ? 'replicas' : 'slaves';
     }
 
     /**
@@ -195,7 +195,7 @@ class Credis_Sentinel
     public function createMasterClient($name)
     {
         $master = $this->getMasterAddressByName($name);
-        if(!isset($master[0]) || !isset($master[1])){
+        if (!isset($master[0]) || !isset($master[1])) {
             throw new CredisException('Master not found');
         }
         return new Credis_Client($master[0], $master[1], $this->_timeout, $this->_persistent, $this->_db, $this->_password, $this->_username);
@@ -208,7 +208,7 @@ class Credis_Sentinel
      */
     public function getMasterClient($name)
     {
-        if(!isset($this->_master[$name])){
+        if (!isset($this->_master[$name])) {
             $this->_master[$name] = $this->createMasterClient($name);
         }
         return $this->_master[$name];
@@ -225,11 +225,11 @@ class Credis_Sentinel
     {
         $slaves = $this->slaves($name);
         $workingSlaves = array();
-        foreach($slaves as $slave) {
-            if(!isset($slave[9])){
+        foreach ($slaves as $slave) {
+            if (!isset($slave[9])) {
                 throw new CredisException('Can\' retrieve slave status');
             }
-            if(!strstr($slave[9],'s_down') && !strstr($slave[9],'disconnected')) {
+            if (!strstr($slave[9], 's_down') && !strstr($slave[9], 'disconnected')) {
                 $workingSlaves[] = new Credis_Client($slave[3], $slave[5], $this->_timeout, $this->_persistent, $this->_db, $this->_password, $this->_username);
             }
         }
@@ -243,7 +243,7 @@ class Credis_Sentinel
      */
     public function getSlaveClients($name)
     {
-        if(!isset($this->_slaves[$name])){
+        if (!isset($this->_slaves[$name])) {
             $this->_slaves[$name] = $this->createSlaveClients($name);
         }
         return $this->_slaves[$name];
@@ -265,27 +265,27 @@ class Credis_Sentinel
      * @throws CredisException
      * @deprecated
      */
-    public function createCluster($name, $db=0, $replicas=128, $selectRandomSlave=true, $writeOnly=false, $masterOnly=false)
+    public function createCluster($name, $db = 0, $replicas = 128, $selectRandomSlave = true, $writeOnly = false, $masterOnly = false)
     {
         $clients = array();
         $workingClients = array();
         $master = $this->master($name);
-        if(strstr($master[9],'s_down') || strstr($master[9],'disconnected')) {
+        if (strstr($master[9], 's_down') || strstr($master[9], 'disconnected')) {
             throw new CredisException('The master is down');
         }
         if (!$masterOnly) {
             $slaves = $this->slaves($name);
-            foreach($slaves as $slave){
-                if(!strstr($slave[9],'s_down') && !strstr($slave[9],'disconnected')) {
-                    $workingClients[] =  array('host'=>$slave[3],'port'=>$slave[5],'master'=>false,'db'=>$db,'password'=>$this->_password);
+            foreach ($slaves as $slave) {
+                if (!strstr($slave[9], 's_down') && !strstr($slave[9], 'disconnected')) {
+                    $workingClients[] = array('host' => $slave[3], 'port' => $slave[5], 'master' => false, 'db' => $db, 'password' => $this->_password);
                 }
             }
-            if(count($workingClients)>0){
-                if($selectRandomSlave){
-                    if(!$writeOnly){
-                        $workingClients[] = array('host'=>$master[3],'port'=>$master[5],'master'=>false,'db'=>$db,'password'=>$this->_password);
+            if (count($workingClients) > 0) {
+                if ($selectRandomSlave) {
+                    if (!$writeOnly) {
+                        $workingClients[] = array('host' => $master[3], 'port' => $master[5], 'master' => false, 'db' => $db, 'password' => $this->_password);
                     }
-                    $clients[] = $workingClients[rand(0,count($workingClients)-1)];
+                    $clients[] = $workingClients[rand(0, count($workingClients) - 1)];
                 } else {
                     $clients = $workingClients;
                 }
@@ -293,8 +293,8 @@ class Credis_Sentinel
         } else {
             $writeOnly = false;
         }
-        $clients[] = array('host'=>$master[3],'port'=>$master[5], 'db'=>$db ,'master'=>true,'write_only'=>$writeOnly,'password'=>$this->_password);
-        return new Credis_Cluster($clients,$replicas,$this->_standAlone);
+        $clients[] = array('host' => $master[3], 'port' => $master[5], 'db' => $db, 'master' => true, 'write_only' => $writeOnly, 'password' => $this->_password);
+        return new Credis_Cluster($clients, $replicas, $this->_standAlone);
     }
 
     /**
@@ -309,9 +309,9 @@ class Credis_Sentinel
      * @throws CredisException
      * @deprecated
      */
-    public function getCluster($name, $db=0, $replicas=128, $selectRandomSlave=true, $writeOnly=false, $masterOnly=false)
+    public function getCluster($name, $db = 0, $replicas = 128, $selectRandomSlave = true, $writeOnly = false, $masterOnly = false)
     {
-        if(!isset($this->_cluster[$name])){
+        if (!isset($this->_cluster[$name])) {
             $this->_cluster[$name] = $this->createCluster($name, $db, $replicas, $selectRandomSlave, $writeOnly, $masterOnly);
         }
         return $this->_cluster[$name];
@@ -325,8 +325,8 @@ class Credis_Sentinel
      */
     public function __call($name, $args)
     {
-        array_unshift($args,$name);
-        return call_user_func(array($this->_client,'sentinel'),$args);
+        array_unshift($args, $name);
+        return call_user_func(array($this->_client, 'sentinel'), $args);
     }
 
     /**
@@ -338,8 +338,7 @@ class Credis_Sentinel
      */
     public function info($section = null)
     {
-        if ($section)
-        {
+        if ($section) {
             return $this->_client->info($section);
         }
         return $this->_client->info();
@@ -362,9 +361,9 @@ class Credis_Sentinel
     public function slaves($name)
     {
         if ($this->_replicaCmd === null) {
-          $this->detectRedisVersion();
+            $this->detectRedisVersion();
         }
-        return $this->_client->sentinel($this->_replicaCmd,$name);
+        return $this->_client->sentinel($this->_replicaCmd, $name);
     }
 
     /**
@@ -374,7 +373,7 @@ class Credis_Sentinel
      */
     public function master($name)
     {
-        return $this->_client->sentinel('master',$name);
+        return $this->_client->sentinel('master', $name);
     }
 
     /**
@@ -384,7 +383,7 @@ class Credis_Sentinel
      */
     public function getMasterAddressByName($name)
     {
-        return $this->_client->sentinel('get-master-addr-by-name',$name);
+        return $this->_client->sentinel('get-master-addr-by-name', $name);
     }
 
     /**
@@ -403,7 +402,7 @@ class Credis_Sentinel
      */
     public function failover($name)
     {
-        return $this->_client->sentinel('failover',$name);
+        return $this->_client->sentinel('failover', $name);
     }
 
     /**

--- a/Sentinel.php
+++ b/Sentinel.php
@@ -85,13 +85,13 @@ class Credis_Sentinel
      * @param string $password (deprecated - use setClientPassword)
      * @throws CredisException
      */
-    public function __construct(Credis_Client $client, $password = NULL, $username = NULL)
+    public function __construct(Credis_Client $client, $password = null, $username = null)
     {
         $client->forceStandalone(); // SENTINEL command not currently supported by phpredis
         $this->_client = $client;
         $this->_password = $password;
         $this->_username = $username;
-        $this->_timeout = NULL;
+        $this->_timeout = null;
         $this->_persistent = '';
         $this->_db = 0;
     }

--- a/tests/CredisClusterTest.php
+++ b/tests/CredisClusterTest.php
@@ -6,210 +6,207 @@ require_once dirname(__FILE__).'/CredisTestCommon.php';
 
 class CredisClusterTest extends CredisTestCommon
 {
-  /** @var Credis_Cluster */
-  protected $cluster;
+    /** @var Credis_Cluster */
+    protected $cluster;
 
-  protected function setUpInternal()
-  {
-    parent::setUpInternal();
+    protected function setUpInternal()
+    {
+        parent::setUpInternal();
 
-    $clients = array_slice($this->redisConfig,0,4);
-    $this->cluster = new Credis_Cluster($clients,2,$this->useStandalone);
-  }
+        $clients = array_slice($this->redisConfig, 0, 4);
+        $this->cluster = new Credis_Cluster($clients, 2, $this->useStandalone);
+    }
 
-  protected function tearDownInternal()
-  {
-    if($this->cluster) {
-      $this->cluster->flushAll();
-      foreach($this->cluster->clients() as $client){
-        if($client->isConnected()) {
-            $client->close();
+    protected function tearDownInternal()
+    {
+        if ($this->cluster) {
+            $this->cluster->flushAll();
+            foreach ($this->cluster->clients() as $client) {
+                if ($client->isConnected()) {
+                    $client->close();
+                }
+            }
+            $this->cluster = null;
         }
-      }
-      $this->cluster = NULL;
     }
-  }
 
-  public function testKeyHashing()
-  {
-      $this->tearDown();
-      $this->cluster = new Credis_Cluster(array_slice($this->redisConfig, 0, 3), 2, $this->useStandalone);
-      $keys = array();
-      $lines = explode("\n", file_get_contents("keys.test"));
-      foreach ($lines as $line) {
-          $pair = explode(':', trim($line));
-          if (count($pair) >= 2) {
-              $keys[$pair[0]] = $pair[1];
-          }
-      }
-      foreach ($keys as $key => $value) {
-          $this->assertTrue($this->cluster->set($key, $value));
-      }
-      $this->cluster = new Credis_Cluster(array_slice($this->redisConfig, 0, 4), 2, true, $this->useStandalone);
-      $hits = 0;
-      foreach ($keys as $key => $value) {
-          if ($this->cluster->all('get',$key)) {
-              $hits++;
-          }
-      }
-      $this->assertEquals(count($keys),$hits);
-  }
-  public function testAlias()
-  {
-      $slicedConfig = array_slice($this->redisConfig, 0, 4);
-      foreach($slicedConfig as $config) {
-          $this->assertEquals($config['port'],$this->cluster->client($config['alias'])->getPort());
-      }
-      foreach($slicedConfig as $offset => $config) {
-          $this->assertEquals($config['port'],$this->cluster->client($offset)->getPort());
-      }
-      $alias = "non-existent-alias";
-      $this->setExpectedExceptionShim('CredisException',"Client $alias does not exist.");
-      $this->cluster->client($alias);
-  }
-  public function testMasterSlave()
-  {
-      $this->tearDown();
-      $this->cluster = new Credis_Cluster(array($this->redisConfig[0],$this->redisConfig[6]), 2, $this->useStandalone);
-      $this->assertTrue($this->cluster->client('master')->set('key','value'));
-      $this->waitForSlaveReplication();
-      $this->assertEquals('value',$this->cluster->client('slave')->get('key'));
-      $this->assertEquals('value',$this->cluster->get('key'));
-      try
-      {
-          $this->cluster->client('slave')->set('key2', 'value');
-          $this->fail('Writing to readonly slave');
-      }
-      catch(CredisException $e)
-      {
-      }
-
-      $this->tearDown();
-      $writeOnlyConfig = $this->redisConfig[0];
-      $writeOnlyConfig['write_only'] = true;
-      $this->cluster = new Credis_Cluster(array($writeOnlyConfig,$this->redisConfig[6]), 2, $this->useStandalone);
-      $this->assertTrue($this->cluster->client('master')->set('key','value'));
-      $this->waitForSlaveReplication();
-      $this->assertEquals('value',$this->cluster->client('slave')->get('key'));
-      $this->assertEquals('value',$this->cluster->get('key'));
-      $this->setExpectedExceptionShim('CredisException');
-      $this->assertFalse($this->cluster->client('slave')->set('key2','value'));
-  }
-  public function testMasterWithoutSlavesAndWriteOnlyFlag()
-  {
-      $this->tearDown();
-      $writeOnlyConfig = $this->redisConfig[0];
-      $writeOnlyConfig['write_only'] = true;
-      $this->cluster = new Credis_Cluster(array($writeOnlyConfig),2,$this->useStandalone);
-      $this->assertTrue($this->cluster->set('key','value'));
-      $this->assertEquals('value',$this->cluster->get('key'));
-  }
-  public function testDontHashForCodeCoverage()
-  {
-    if (method_exists($this,'assertIsArray')){
-        $this->assertIsArray($this->cluster->info());
-    } else {
-        $this->assertInternalType('array',$this->cluster->info());
+    public function testKeyHashing()
+    {
+        $this->tearDown();
+        $this->cluster = new Credis_Cluster(array_slice($this->redisConfig, 0, 3), 2, $this->useStandalone);
+        $keys = array();
+        $lines = explode("\n", file_get_contents("keys.test"));
+        foreach ($lines as $line) {
+            $pair = explode(':', trim($line));
+            if (count($pair) >= 2) {
+                $keys[$pair[0]] = $pair[1];
+            }
+        }
+        foreach ($keys as $key => $value) {
+            $this->assertTrue($this->cluster->set($key, $value));
+        }
+        $this->cluster = new Credis_Cluster(array_slice($this->redisConfig, 0, 4), 2, true, $this->useStandalone);
+        $hits = 0;
+        foreach ($keys as $key => $value) {
+            if ($this->cluster->all('get', $key)) {
+                $hits++;
+            }
+        }
+        $this->assertEquals(count($keys), $hits);
     }
-  }
-  public function testByHash()
-  {
-      $this->cluster->set('key','value');
-      $this->assertEquals(6379,$this->cluster->byHash('key')->getPort());
-  }
-  public function testRwsplit()
-  {
-    $readOnlyCommands = array(
-        'EXISTS',
-        'TYPE',
-        'KEYS',
-        'SCAN',
-        'RANDOMKEY',
-        'TTL',
-        'GET',
-        'MGET',
-        'SUBSTR',
-        'STRLEN',
-        'GETRANGE',
-        'GETBIT',
-        'LLEN',
-        'LRANGE',
-        'LINDEX',
-        'SCARD',
-        'SISMEMBER',
-        'SINTER',
-        'SUNION',
-        'SDIFF',
-        'SMEMBERS',
-        'SSCAN',
-        'SRANDMEMBER',
-        'ZRANGE',
-        'ZREVRANGE',
-        'ZRANGEBYSCORE',
-        'ZREVRANGEBYSCORE',
-        'ZCARD',
-        'ZSCORE',
-        'ZCOUNT',
-        'ZRANK',
-        'ZREVRANK',
-        'ZSCAN',
-        'HGET',
-        'HMGET',
-        'HEXISTS',
-        'HLEN',
-        'HKEYS',
-        'HVALS',
-        'HGETALL',
-        'HSCAN',
-        'PING',
-        'AUTH',
-        'SELECT',
-        'ECHO',
-        'QUIT',
-        'OBJECT',
-        'BITCOUNT',
-        'TIME',
-        'SORT'
-    );
-    foreach($readOnlyCommands as $command){
-        $this->assertTrue($this->cluster->isReadOnlyCommand($command));
+    public function testAlias()
+    {
+        $slicedConfig = array_slice($this->redisConfig, 0, 4);
+        foreach ($slicedConfig as $config) {
+            $this->assertEquals($config['port'], $this->cluster->client($config['alias'])->getPort());
+        }
+        foreach ($slicedConfig as $offset => $config) {
+            $this->assertEquals($config['port'], $this->cluster->client($offset)->getPort());
+        }
+        $alias = "non-existent-alias";
+        $this->setExpectedExceptionShim('CredisException', "Client $alias does not exist.");
+        $this->cluster->client($alias);
     }
-    $this->assertFalse($this->cluster->isReadOnlyCommand("SET"));
-    $this->assertFalse($this->cluster->isReadOnlyCommand("HDEL"));
-    $this->assertFalse($this->cluster->isReadOnlyCommand("RPUSH"));
-    $this->assertFalse($this->cluster->isReadOnlyCommand("SMOVE"));
-    $this->assertFalse($this->cluster->isReadOnlyCommand("ZADD"));
-  }
-  public function testCredisClientInstancesInConstructor()
-  {
-      $this->tearDown();
-      $two = new Credis_Client($this->redisConfig[1]['host'], $this->redisConfig[1]['port']);
-      $three = new Credis_Client($this->redisConfig[2]['host'], $this->redisConfig[2]['port']);
-      $four = new Credis_Client($this->redisConfig[3]['host'], $this->redisConfig[3]['port']);
-      $this->cluster = new Credis_Cluster(array($two,$three,$four),2,$this->useStandalone);
-      $this->assertTrue($this->cluster->set('key','value'));
-      $this->assertEquals('value',$this->cluster->get('key'));
-      $this->setExpectedExceptionShim('CredisException','Server should either be an array or an instance of Credis_Client');
-      new Credis_Cluster(array(new stdClass()),2,$this->useStandalone);
-  }
-  public function testSetMasterClient()
-  {
-      $this->tearDown();
-      $master = new Credis_Client($this->redisConfig[0]['host'], $this->redisConfig[0]['port']);
-      $slave = new Credis_Client($this->redisConfig[6]['host'], $this->redisConfig[6]['port']);
+    public function testMasterSlave()
+    {
+        $this->tearDown();
+        $this->cluster = new Credis_Cluster(array($this->redisConfig[0],$this->redisConfig[6]), 2, $this->useStandalone);
+        $this->assertTrue($this->cluster->client('master')->set('key', 'value'));
+        $this->waitForSlaveReplication();
+        $this->assertEquals('value', $this->cluster->client('slave')->get('key'));
+        $this->assertEquals('value', $this->cluster->get('key'));
+        try {
+            $this->cluster->client('slave')->set('key2', 'value');
+            $this->fail('Writing to readonly slave');
+        } catch(CredisException $e) {
+        }
 
-      $this->cluster = new Credis_Cluster(array($slave),2,$this->useStandalone);
-      $this->assertInstanceOf('Credis_Cluster',$this->cluster->setMasterClient($master));
-      $this->assertCount(2,$this->cluster->clients());
-      $this->assertEquals($this->redisConfig[6]['port'], $this->cluster->client(0)->getPort());
-      $this->assertEquals($this->redisConfig[0]['port'], $this->cluster->client('master')->getPort());
+        $this->tearDown();
+        $writeOnlyConfig = $this->redisConfig[0];
+        $writeOnlyConfig['write_only'] = true;
+        $this->cluster = new Credis_Cluster(array($writeOnlyConfig,$this->redisConfig[6]), 2, $this->useStandalone);
+        $this->assertTrue($this->cluster->client('master')->set('key', 'value'));
+        $this->waitForSlaveReplication();
+        $this->assertEquals('value', $this->cluster->client('slave')->get('key'));
+        $this->assertEquals('value', $this->cluster->get('key'));
+        $this->setExpectedExceptionShim('CredisException');
+        $this->assertFalse($this->cluster->client('slave')->set('key2', 'value'));
+    }
+    public function testMasterWithoutSlavesAndWriteOnlyFlag()
+    {
+        $this->tearDown();
+        $writeOnlyConfig = $this->redisConfig[0];
+        $writeOnlyConfig['write_only'] = true;
+        $this->cluster = new Credis_Cluster(array($writeOnlyConfig), 2, $this->useStandalone);
+        $this->assertTrue($this->cluster->set('key', 'value'));
+        $this->assertEquals('value', $this->cluster->get('key'));
+    }
+    public function testDontHashForCodeCoverage()
+    {
+        if (method_exists($this, 'assertIsArray')) {
+            $this->assertIsArray($this->cluster->info());
+        } else {
+            $this->assertInternalType('array', $this->cluster->info());
+        }
+    }
+    public function testByHash()
+    {
+        $this->cluster->set('key', 'value');
+        $this->assertEquals(6379, $this->cluster->byHash('key')->getPort());
+    }
+    public function testRwsplit()
+    {
+        $readOnlyCommands = array(
+            'EXISTS',
+            'TYPE',
+            'KEYS',
+            'SCAN',
+            'RANDOMKEY',
+            'TTL',
+            'GET',
+            'MGET',
+            'SUBSTR',
+            'STRLEN',
+            'GETRANGE',
+            'GETBIT',
+            'LLEN',
+            'LRANGE',
+            'LINDEX',
+            'SCARD',
+            'SISMEMBER',
+            'SINTER',
+            'SUNION',
+            'SDIFF',
+            'SMEMBERS',
+            'SSCAN',
+            'SRANDMEMBER',
+            'ZRANGE',
+            'ZREVRANGE',
+            'ZRANGEBYSCORE',
+            'ZREVRANGEBYSCORE',
+            'ZCARD',
+            'ZSCORE',
+            'ZCOUNT',
+            'ZRANK',
+            'ZREVRANK',
+            'ZSCAN',
+            'HGET',
+            'HMGET',
+            'HEXISTS',
+            'HLEN',
+            'HKEYS',
+            'HVALS',
+            'HGETALL',
+            'HSCAN',
+            'PING',
+            'AUTH',
+            'SELECT',
+            'ECHO',
+            'QUIT',
+            'OBJECT',
+            'BITCOUNT',
+            'TIME',
+            'SORT'
+        );
+        foreach ($readOnlyCommands as $command) {
+            $this->assertTrue($this->cluster->isReadOnlyCommand($command));
+        }
+        $this->assertFalse($this->cluster->isReadOnlyCommand("SET"));
+        $this->assertFalse($this->cluster->isReadOnlyCommand("HDEL"));
+        $this->assertFalse($this->cluster->isReadOnlyCommand("RPUSH"));
+        $this->assertFalse($this->cluster->isReadOnlyCommand("SMOVE"));
+        $this->assertFalse($this->cluster->isReadOnlyCommand("ZADD"));
+    }
+    public function testCredisClientInstancesInConstructor()
+    {
+        $this->tearDown();
+        $two = new Credis_Client($this->redisConfig[1]['host'], $this->redisConfig[1]['port']);
+        $three = new Credis_Client($this->redisConfig[2]['host'], $this->redisConfig[2]['port']);
+        $four = new Credis_Client($this->redisConfig[3]['host'], $this->redisConfig[3]['port']);
+        $this->cluster = new Credis_Cluster(array($two,$three,$four), 2, $this->useStandalone);
+        $this->assertTrue($this->cluster->set('key', 'value'));
+        $this->assertEquals('value', $this->cluster->get('key'));
+        $this->setExpectedExceptionShim('CredisException', 'Server should either be an array or an instance of Credis_Client');
+        new Credis_Cluster(array(new stdClass()), 2, $this->useStandalone);
+    }
+    public function testSetMasterClient()
+    {
+        $this->tearDown();
+        $master = new Credis_Client($this->redisConfig[0]['host'], $this->redisConfig[0]['port']);
+        $slave = new Credis_Client($this->redisConfig[6]['host'], $this->redisConfig[6]['port']);
 
-      $this->cluster = new Credis_Cluster(array($this->redisConfig[0]), 2, $this->useStandalone);
-      $this->assertInstanceOf('Credis_Cluster',$this->cluster->setMasterClient(new Credis_Client($this->redisConfig[1]['host'], $this->redisConfig[1]['port'])));
-      $this->assertEquals($this->redisConfig[0]['port'], $this->cluster->client('master')->getPort());
+        $this->cluster = new Credis_Cluster(array($slave), 2, $this->useStandalone);
+        $this->assertInstanceOf('Credis_Cluster', $this->cluster->setMasterClient($master));
+        $this->assertCount(2, $this->cluster->clients());
+        $this->assertEquals($this->redisConfig[6]['port'], $this->cluster->client(0)->getPort());
+        $this->assertEquals($this->redisConfig[0]['port'], $this->cluster->client('master')->getPort());
 
-      $this->cluster = new Credis_Cluster(array($slave),2,$this->useStandalone);
-      $this->assertInstanceOf('Credis_Cluster',$this->cluster->setMasterClient($master,true));
-      $this->assertCount(1,$this->cluster->clients());
-  }
+        $this->cluster = new Credis_Cluster(array($this->redisConfig[0]), 2, $this->useStandalone);
+        $this->assertInstanceOf('Credis_Cluster', $this->cluster->setMasterClient(new Credis_Client($this->redisConfig[1]['host'], $this->redisConfig[1]['port'])));
+        $this->assertEquals($this->redisConfig[0]['port'], $this->cluster->client('master')->getPort());
+
+        $this->cluster = new Credis_Cluster(array($slave), 2, $this->useStandalone);
+        $this->assertInstanceOf('Credis_Cluster', $this->cluster->setMasterClient($master, true));
+        $this->assertCount(1, $this->cluster->clients());
+    }
 }

--- a/tests/CredisSentinelTest.php
+++ b/tests/CredisSentinelTest.php
@@ -7,239 +7,230 @@ require_once dirname(__FILE__).'/CredisTestCommon.php';
 
 class CredisSentinelTest extends CredisTestCommon
 {
-  /** @var Credis_Sentinel */
-  protected $sentinel;
+    /** @var Credis_Sentinel */
+    protected $sentinel;
 
-  protected $sentinelConfig;
+    protected $sentinelConfig;
 
-  protected function setUpInternal()
-  {
-    parent::setUpInternal();
-    if($this->sentinelConfig === NULL) {
-      $configFile = dirname(__FILE__).'/sentinel_config.json';
-      if( ! file_exists($configFile) || ! ($config = file_get_contents($configFile))) {
-        $this->markTestSkipped('Could not load '.$configFile);
-        return;
-      }
-      $this->sentinelConfig = json_decode($config);
-    }
-
-    $sentinelClient = new Credis_Client($this->sentinelConfig->host, $this->sentinelConfig->port);
-    $this->sentinel = new Credis_Sentinel($sentinelClient);
-    if($this->useStandalone) {
-      $this->sentinel->forceStandalone();
-    }
-    $this->waitForSlaveReplication();
-  }
-
-  public static function setUpBeforeClassInternal()
-  {
-    parent::setUpBeforeClassInternal();
-    if(preg_match('/^WIN/',strtoupper(PHP_OS))){
-      echo "\tredis-server redis-sentinel.conf --sentinel".PHP_EOL.PHP_EOL;
-    } else {
-      sleep(2);
-      chdir(__DIR__);
-      copy('redis-sentinel.conf','redis-sentinel.conf.bak');
-      exec('redis-server redis-sentinel.conf --sentinel');
-      // wait for redis to initialize
-      sleep(1);
-    }
-  }
-
-  public static function tearDownAfterClassInternal()
-  {
-    parent::tearDownAfterClassInternal();
-    if(preg_match('/^WIN/',strtoupper(PHP_OS))){
-      echo "Please kill all Redis instances manually:".PHP_EOL;
-    } else {
-      chdir(__DIR__);
-      @unlink('redis-sentinel.conf');
-      @copy('redis-sentinel.conf.bak','redis-sentinel.conf');
-    }
-  }
-
-  protected function tearDownInternal()
-  {
-    if($this->sentinel) {
-      $this->sentinel = NULL;
-    }
-  }
-  public function testMasterClient()
-  {
-      $master = $this->sentinel->getMasterClient($this->sentinelConfig->clustername);
-      $this->assertInstanceOf('Credis_Client',$master);
-      $this->assertEquals($this->redisConfig[0]['port'],$master->getPort());
-      $this->setExpectedExceptionShim('CredisException','Master not found');
-      $this->sentinel->getMasterClient('non-existing-cluster');
-  }
-  public function testMasters()
-  {
-      $masters = $this->sentinel->masters();
-      if (method_exists($this,'assertIsArray')){
-        $this->assertIsArray($masters);
-      } else {
-        $this->assertInternalType('array',$masters);
-      }
-      $this->assertCount(2,$masters);
-      $this->assertArrayHasKey(0,$masters);
-      $this->assertArrayHasKey(1,$masters);
-      $this->assertArrayHasKey(1,$masters[0]);
-      $this->assertArrayHasKey(1,$masters[1]);
-      $this->assertArrayHasKey(5,$masters[1]);
-      if($masters[0][1] == 'masterdown'){
-          $this->assertEquals($this->sentinelConfig->clustername,$masters[1][1]);
-          $this->assertEquals($this->redisConfig[0]['port'],$masters[1][5]);
-      } else {
-          $this->assertEquals('masterdown',$masters[1][1]);
-          $this->assertEquals($this->sentinelConfig->clustername,$masters[0][1]);
-          $this->assertEquals($this->redisConfig[0]['port'],$masters[0][5]);
-      }
-  }
-  public function testMaster()
-  {
-      $master = $this->sentinel->master($this->sentinelConfig->clustername);
-      if (method_exists($this,'assertIsArray')){
-        $this->assertIsArray($master);
-      } else {
-        $this->assertInternalType('array',$master);
-      }
-      $this->assertArrayHasKey(1,$master);
-      $this->assertArrayHasKey(5,$master);
-      $this->assertEquals($this->sentinelConfig->clustername,$master[1]);
-      $this->assertEquals($this->redisConfig[0]['port'],$master[5]);
-
-      $this->setExpectedExceptionShim('CredisException','No such master with that name');
-      $this->sentinel->master('non-existing-cluster');
-  }
-  public function testSlaveClient()
-  {
-      $slaves = $this->sentinel->getSlaveClients($this->sentinelConfig->clustername);
-      if (method_exists($this,'assertIsArray')){
-        $this->assertIsArray($slaves);
-      } else {
-        $this->assertInternalType('array',$slaves);
-      }
-      $this->assertCount(1,$slaves);
-      foreach($slaves as $slave){
-          $this->assertInstanceOf('Credis_Client',$slave);
-      }
-      $this->setExpectedExceptionShim('CredisException','No such master with that name');
-      $this->sentinel->getSlaveClients('non-existing-cluster');
-  }
-  public function testSlaves()
-  {
-      $slaves = $this->sentinel->slaves($this->sentinelConfig->clustername);
-      if (method_exists($this,'assertIsArray')){
-        $this->assertIsArray($slaves);
-      } else {
-        $this->assertInternalType('array',$slaves);
-      }
-      $this->assertCount(1,$slaves);
-      $this->assertArrayHasKey(0,$slaves);
-      $this->assertArrayHasKey(5,$slaves[0]);
-      $this->assertEquals(6385,$slaves[0][5]);
-
-      $slaves = $this->sentinel->slaves('masterdown');
-      if (method_exists($this,'assertIsArray')){
-        $this->assertIsArray($slaves);
-      } else {
-        $this->assertInternalType('array',$slaves);
-      }
-      $this->assertCount(0,$slaves);
-
-      $this->setExpectedExceptionShim('CredisException','No such master with that name');
-      $this->sentinel->slaves('non-existing-cluster');
-  }
-  public function testNonExistingClusterNameWhenCreatingSlaves()
-  {
-      $this->setExpectedExceptionShim('CredisException','No such master with that name');
-      $this->sentinel->createSlaveClients('non-existing-cluster');
-  }
-  public function testCreateCluster()
-  {
-      $cluster = $this->sentinel->createCluster($this->sentinelConfig->clustername);
-      $this->assertInstanceOf('Credis_Cluster',$cluster);
-      $this->assertCount(2,$cluster->clients());
-      $cluster = $this->sentinel->createCluster($this->sentinelConfig->clustername,0,1,false);
-      $this->assertInstanceOf('Credis_Cluster',$cluster);
-      $this->assertCount(2,$cluster->clients());
-      $this->setExpectedExceptionShim('CredisException','The master is down');
-      $this->sentinel->createCluster($this->sentinelConfig->downclustername);
-  }
-  public function testGetCluster()
-  {
-      $cluster = $this->sentinel->getCluster($this->sentinelConfig->clustername);
-      $this->assertInstanceOf('Credis_Cluster',$cluster);
-      $this->assertCount(2,$cluster->clients());
-  }
-  public function testGetClusterOnDbNumber2()
-  {
-      $cluster = $this->sentinel->getCluster($this->sentinelConfig->clustername,2);
-      $this->assertInstanceOf('Credis_Cluster',$cluster);
-      $this->assertCount(2,$cluster->clients());
-      $clients = $cluster->clients();
-      $this->assertEquals(2,$clients[0]->getSelectedDb());
-      $this->assertEquals(2,$clients[1]->getSelectedDb());
-  }
-  public function testGetMasterAddressByName()
-  {
-      $address = $this->sentinel->getMasterAddressByName($this->sentinelConfig->clustername);
-      if (method_exists($this,'assertIsArray')){
-        $this->assertIsArray($address);
-      } else {
-        $this->assertInternalType('array',$address);
-      }
-      $this->assertCount(2,$address);
-      $this->assertArrayHasKey(0,$address);
-      $this->assertArrayHasKey(1,$address);
-      $this->assertEquals($this->redisConfig[0]['host'],$address[0]);
-      $this->assertEquals($this->redisConfig[0]['port'],$address[1]);
-  }
-
-  public function testPing()
-  {
-    $pong = $this->sentinel->ping();
-    $this->assertEquals("PONG",$pong);
-  }
-
-  public function testGetHostAndPort()
-  {
-      $host = 'localhost';
-      $port = '123456';
-
-      $client = $this->createMock('\Credis_Client');
-      $sentinel = new Credis_Sentinel($client);
-
-      $client->expects($this->once())->method('getHost')->willReturn($host);
-      $client->expects($this->once())->method('getPort')->willReturn($port);
-
-      $this->assertEquals($host, $sentinel->getHost());
-      $this->assertEquals($port, $sentinel->getPort());
-  }
-  public function testNonExistingMethod()
-  {
-      try
-      {
-        $this->sentinel->bla();
-      }
-      catch(CredisException $e)
-      {
-        if (strpos($e->getMessage(), 'bla') !== false)
-        {
-          if (strpos($e->getMessage(), 'unknown subcommand') !== false)
-          {
-            $this->assertStringStartsWith('ERR unknown subcommand \'bla\'', $e->getMessage());
-          }
-          else
-          {
-            $this->assertStringStartsWith('ERR Unknown sentinel subcommand \'bla\'', $e->getMessage());
-          }
+    protected function setUpInternal()
+    {
+        parent::setUpInternal();
+        if ($this->sentinelConfig === null) {
+            $configFile = dirname(__FILE__).'/sentinel_config.json';
+            if (! file_exists($configFile) || ! ($config = file_get_contents($configFile))) {
+                $this->markTestSkipped('Could not load '.$configFile);
+                return;
+            }
+            $this->sentinelConfig = json_decode($config);
         }
-        else
-        {
-          $this->assertStringStartsWith('ERR Unknown subcommand or wrong number of arguments', $e->getMessage());
+
+        $sentinelClient = new Credis_Client($this->sentinelConfig->host, $this->sentinelConfig->port);
+        $this->sentinel = new Credis_Sentinel($sentinelClient);
+        if ($this->useStandalone) {
+            $this->sentinel->forceStandalone();
         }
-      }
-  }
+        $this->waitForSlaveReplication();
+    }
+
+    public static function setUpBeforeClassInternal()
+    {
+        parent::setUpBeforeClassInternal();
+        if (preg_match('/^WIN/', strtoupper(PHP_OS))) {
+            echo "\tredis-server redis-sentinel.conf --sentinel".PHP_EOL.PHP_EOL;
+        } else {
+            sleep(2);
+            chdir(__DIR__);
+            copy('redis-sentinel.conf', 'redis-sentinel.conf.bak');
+            exec('redis-server redis-sentinel.conf --sentinel');
+            // wait for redis to initialize
+            sleep(1);
+        }
+    }
+
+    public static function tearDownAfterClassInternal()
+    {
+        parent::tearDownAfterClassInternal();
+        if (preg_match('/^WIN/', strtoupper(PHP_OS))) {
+            echo "Please kill all Redis instances manually:".PHP_EOL;
+        } else {
+            chdir(__DIR__);
+            @unlink('redis-sentinel.conf');
+            @copy('redis-sentinel.conf.bak', 'redis-sentinel.conf');
+        }
+    }
+
+    protected function tearDownInternal()
+    {
+        if ($this->sentinel) {
+            $this->sentinel = null;
+        }
+    }
+    public function testMasterClient()
+    {
+        $master = $this->sentinel->getMasterClient($this->sentinelConfig->clustername);
+        $this->assertInstanceOf('Credis_Client', $master);
+        $this->assertEquals($this->redisConfig[0]['port'], $master->getPort());
+        $this->setExpectedExceptionShim('CredisException', 'Master not found');
+        $this->sentinel->getMasterClient('non-existing-cluster');
+    }
+    public function testMasters()
+    {
+        $masters = $this->sentinel->masters();
+        if (method_exists($this, 'assertIsArray')) {
+            $this->assertIsArray($masters);
+        } else {
+            $this->assertInternalType('array', $masters);
+        }
+        $this->assertCount(2, $masters);
+        $this->assertArrayHasKey(0, $masters);
+        $this->assertArrayHasKey(1, $masters);
+        $this->assertArrayHasKey(1, $masters[0]);
+        $this->assertArrayHasKey(1, $masters[1]);
+        $this->assertArrayHasKey(5, $masters[1]);
+        if ($masters[0][1] == 'masterdown') {
+            $this->assertEquals($this->sentinelConfig->clustername, $masters[1][1]);
+            $this->assertEquals($this->redisConfig[0]['port'], $masters[1][5]);
+        } else {
+            $this->assertEquals('masterdown', $masters[1][1]);
+            $this->assertEquals($this->sentinelConfig->clustername, $masters[0][1]);
+            $this->assertEquals($this->redisConfig[0]['port'], $masters[0][5]);
+        }
+    }
+    public function testMaster()
+    {
+        $master = $this->sentinel->master($this->sentinelConfig->clustername);
+        if (method_exists($this, 'assertIsArray')) {
+            $this->assertIsArray($master);
+        } else {
+            $this->assertInternalType('array', $master);
+        }
+        $this->assertArrayHasKey(1, $master);
+        $this->assertArrayHasKey(5, $master);
+        $this->assertEquals($this->sentinelConfig->clustername, $master[1]);
+        $this->assertEquals($this->redisConfig[0]['port'], $master[5]);
+
+        $this->setExpectedExceptionShim('CredisException', 'No such master with that name');
+        $this->sentinel->master('non-existing-cluster');
+    }
+    public function testSlaveClient()
+    {
+        $slaves = $this->sentinel->getSlaveClients($this->sentinelConfig->clustername);
+        if (method_exists($this, 'assertIsArray')) {
+            $this->assertIsArray($slaves);
+        } else {
+            $this->assertInternalType('array', $slaves);
+        }
+        $this->assertCount(1, $slaves);
+        foreach ($slaves as $slave) {
+            $this->assertInstanceOf('Credis_Client', $slave);
+        }
+        $this->setExpectedExceptionShim('CredisException', 'No such master with that name');
+        $this->sentinel->getSlaveClients('non-existing-cluster');
+    }
+    public function testSlaves()
+    {
+        $slaves = $this->sentinel->slaves($this->sentinelConfig->clustername);
+        if (method_exists($this, 'assertIsArray')) {
+            $this->assertIsArray($slaves);
+        } else {
+            $this->assertInternalType('array', $slaves);
+        }
+        $this->assertCount(1, $slaves);
+        $this->assertArrayHasKey(0, $slaves);
+        $this->assertArrayHasKey(5, $slaves[0]);
+        $this->assertEquals(6385, $slaves[0][5]);
+
+        $slaves = $this->sentinel->slaves('masterdown');
+        if (method_exists($this, 'assertIsArray')) {
+            $this->assertIsArray($slaves);
+        } else {
+            $this->assertInternalType('array', $slaves);
+        }
+        $this->assertCount(0, $slaves);
+
+        $this->setExpectedExceptionShim('CredisException', 'No such master with that name');
+        $this->sentinel->slaves('non-existing-cluster');
+    }
+    public function testNonExistingClusterNameWhenCreatingSlaves()
+    {
+        $this->setExpectedExceptionShim('CredisException', 'No such master with that name');
+        $this->sentinel->createSlaveClients('non-existing-cluster');
+    }
+    public function testCreateCluster()
+    {
+        $cluster = $this->sentinel->createCluster($this->sentinelConfig->clustername);
+        $this->assertInstanceOf('Credis_Cluster', $cluster);
+        $this->assertCount(2, $cluster->clients());
+        $cluster = $this->sentinel->createCluster($this->sentinelConfig->clustername, 0, 1, false);
+        $this->assertInstanceOf('Credis_Cluster', $cluster);
+        $this->assertCount(2, $cluster->clients());
+        $this->setExpectedExceptionShim('CredisException', 'The master is down');
+        $this->sentinel->createCluster($this->sentinelConfig->downclustername);
+    }
+    public function testGetCluster()
+    {
+        $cluster = $this->sentinel->getCluster($this->sentinelConfig->clustername);
+        $this->assertInstanceOf('Credis_Cluster', $cluster);
+        $this->assertCount(2, $cluster->clients());
+    }
+    public function testGetClusterOnDbNumber2()
+    {
+        $cluster = $this->sentinel->getCluster($this->sentinelConfig->clustername, 2);
+        $this->assertInstanceOf('Credis_Cluster', $cluster);
+        $this->assertCount(2, $cluster->clients());
+        $clients = $cluster->clients();
+        $this->assertEquals(2, $clients[0]->getSelectedDb());
+        $this->assertEquals(2, $clients[1]->getSelectedDb());
+    }
+    public function testGetMasterAddressByName()
+    {
+        $address = $this->sentinel->getMasterAddressByName($this->sentinelConfig->clustername);
+        if (method_exists($this, 'assertIsArray')) {
+            $this->assertIsArray($address);
+        } else {
+            $this->assertInternalType('array', $address);
+        }
+        $this->assertCount(2, $address);
+        $this->assertArrayHasKey(0, $address);
+        $this->assertArrayHasKey(1, $address);
+        $this->assertEquals($this->redisConfig[0]['host'], $address[0]);
+        $this->assertEquals($this->redisConfig[0]['port'], $address[1]);
+    }
+
+    public function testPing()
+    {
+        $pong = $this->sentinel->ping();
+        $this->assertEquals("PONG", $pong);
+    }
+
+    public function testGetHostAndPort()
+    {
+        $host = 'localhost';
+        $port = '123456';
+
+        $client = $this->createMock('\Credis_Client');
+        $sentinel = new Credis_Sentinel($client);
+
+        $client->expects($this->once())->method('getHost')->willReturn($host);
+        $client->expects($this->once())->method('getPort')->willReturn($port);
+
+        $this->assertEquals($host, $sentinel->getHost());
+        $this->assertEquals($port, $sentinel->getPort());
+    }
+    public function testNonExistingMethod()
+    {
+        try {
+            $this->sentinel->bla();
+        } catch(CredisException $e) {
+            if (strpos($e->getMessage(), 'bla') !== false) {
+                if (strpos($e->getMessage(), 'unknown subcommand') !== false) {
+                    $this->assertStringStartsWith('ERR unknown subcommand \'bla\'', $e->getMessage());
+                } else {
+                    $this->assertStringStartsWith('ERR Unknown sentinel subcommand \'bla\'', $e->getMessage());
+                }
+            } else {
+                $this->assertStringStartsWith('ERR Unknown subcommand or wrong number of arguments', $e->getMessage());
+            }
+        }
+    }
 }

--- a/tests/CredisStandaloneClusterTest.php
+++ b/tests/CredisStandaloneClusterTest.php
@@ -4,27 +4,27 @@ require_once dirname(__FILE__).'/CredisClusterTest.php';
 
 class CredisStandaloneClusterTest extends CredisClusterTest
 {
-  protected $useStandalone = TRUE;
-  protected function tearDownInternal()
-  {
-    if($this->cluster) {
-        foreach($this->cluster->clients() as $client){
-            if($client->isConnected()) {
-                $client->close();
+    protected $useStandalone = true;
+    protected function tearDownInternal()
+    {
+        if ($this->cluster) {
+            foreach ($this->cluster->clients() as $client) {
+                if ($client->isConnected()) {
+                    $client->close();
+                }
             }
+            $this->cluster = null;
         }
-        $this->cluster = NULL;
     }
-  }
-  public function testMasterSlave()
-  {
-    $this->tearDown();
-    $this->cluster = new Credis_Cluster(array($this->redisConfig[0],$this->redisConfig[6]), 2, $this->useStandalone);
-    $this->assertTrue($this->cluster->client('master')->set('key','value'));
-    $this->waitForSlaveReplication();
-    $this->assertEquals('value',$this->cluster->client('slave')->get('key'));
-    $this->assertEquals('value',$this->cluster->get('key'));
-    $this->setExpectedExceptionShim('CredisException','READONLY You can\'t write against a read only replica.');
-    $this->cluster->client('slave')->set('key2','value');
-  }
+    public function testMasterSlave()
+    {
+        $this->tearDown();
+        $this->cluster = new Credis_Cluster(array($this->redisConfig[0],$this->redisConfig[6]), 2, $this->useStandalone);
+        $this->assertTrue($this->cluster->client('master')->set('key', 'value'));
+        $this->waitForSlaveReplication();
+        $this->assertEquals('value', $this->cluster->client('slave')->get('key'));
+        $this->assertEquals('value', $this->cluster->get('key'));
+        $this->setExpectedExceptionShim('CredisException', 'READONLY You can\'t write against a read only replica.');
+        $this->cluster->client('slave')->set('key2', 'value');
+    }
 }

--- a/tests/CredisStandaloneSentinelTest.php
+++ b/tests/CredisStandaloneSentinelTest.php
@@ -4,5 +4,5 @@ require_once dirname(__FILE__).'/CredisSentinelTest.php';
 
 class CredisStandaloneSentinelTest extends CredisSentinelTest
 {
-    protected $useStandalone = TRUE;
+    protected $useStandalone = true;
 }

--- a/tests/CredisStandaloneTest.php
+++ b/tests/CredisStandaloneTest.php
@@ -4,28 +4,31 @@ require_once dirname(__FILE__).'/CredisTest.php';
 
 class CredisStandaloneTest extends CredisTest
 {
-    protected $useStandalone = TRUE;
+    protected $useStandalone = true;
 
-  public function testPersistentConnectionsOnStandAloneTcpConnection()
-  {
-      $this->credis->close();
-      $this->credis = new Credis_Client('tcp://'.$this->redisConfig[0]['host'] . ':' . $this->redisConfig[0]['port'] . '/persistent');
-      $this->credis->forceStandalone();
-      $this->credis->set('key','value');
-      $this->assertEquals('value',$this->credis->get('key'));
-  }
-
-    public function testPersistentvsNonPersistent() {$this->assertTrue(true);}
-
-    public function testStandAloneArgumentsExtra()
+    public function testPersistentConnectionsOnStandAloneTcpConnection()
     {
-        $this->assertTrue($this->credis->hMSet('hash', array('field1' => 'value1', 'field2' => 'value2'), 'field3', 'value3'));
-        $this->assertEquals(array('field1' => 'value1', 'field2' => 'value2', 'field3' =>'value3'), $this->credis->hMGet('hash', array('field1','field2','field3')));
+        $this->credis->close();
+        $this->credis = new Credis_Client('tcp://'.$this->redisConfig[0]['host'] . ':' . $this->redisConfig[0]['port'] . '/persistent');
+        $this->credis->forceStandalone();
+        $this->credis->set('key', 'value');
+        $this->assertEquals('value', $this->credis->get('key'));
     }
 
-    public function testStandAloneMultiPipelineThrowsException()
-    {
-        $this->setExpectedExceptionShim('CredisException','A pipeline is already in use and only one pipeline is supported.');
-        $this->credis->pipeline()->pipeline();
-    }
+      public function testPersistentvsNonPersistent()
+      {
+          $this->assertTrue(true);
+      }
+
+      public function testStandAloneArgumentsExtra()
+      {
+          $this->assertTrue($this->credis->hMSet('hash', array('field1' => 'value1', 'field2' => 'value2'), 'field3', 'value3'));
+          $this->assertEquals(array('field1' => 'value1', 'field2' => 'value2', 'field3' =>'value3'), $this->credis->hMGet('hash', array('field1','field2','field3')));
+      }
+
+      public function testStandAloneMultiPipelineThrowsException()
+      {
+          $this->setExpectedExceptionShim('CredisException', 'A pipeline is already in use and only one pipeline is supported.');
+          $this->credis->pipeline()->pipeline();
+      }
 }

--- a/tests/CredisTest.php
+++ b/tests/CredisTest.php
@@ -12,21 +12,21 @@ class CredisTest extends CredisTestCommon
     {
         parent::setUpInternal();
         $this->credis = new Credis_Client($this->redisConfig[0]['host'], $this->redisConfig[0]['port'], $this->redisConfig[0]['timeout']);
-        if($this->useStandalone) {
+        if ($this->useStandalone) {
             $this->credis->forceStandalone();
         }
         $this->credis->flushDb();
     }
     protected function tearDownInternal()
     {
-        if($this->credis) {
+        if ($this->credis) {
             $this->credis->close();
-            $this->credis = NULL;
+            $this->credis = null;
         }
     }
     public function testFlush()
     {
-        $this->credis->set('foo','FOO');
+        $this->credis->set('foo', 'FOO');
         $this->assertTrue($this->credis->flushDb());
         $this->assertFalse($this->credis->get('foo'));
     }
@@ -61,7 +61,7 @@ class CredisTest extends CredisTestCommon
     public function testScalars()
     {
         // Basic get/set
-        $this->credis->set('foo','FOO');
+        $this->credis->set('foo', 'FOO');
         $this->assertEquals('FOO', $this->credis->get('foo'));
         $this->assertFalse($this->credis->get('nil'));
 
@@ -70,12 +70,12 @@ class CredisTest extends CredisTestCommon
         $this->assertEquals($this->credis->exists('nil'), 0);
 
         // Empty string
-        $this->credis->set('empty','');
+        $this->credis->set('empty', '');
         $this->assertEquals('', $this->credis->get('empty'));
 
         // UTF-8 characters
         $utf8str = str_repeat("quarter: ¼, micro: µ, thorn: Þ, ", 500);
-        $this->credis->set('utf8',$utf8str);
+        $this->credis->set('utf8', $utf8str);
         $this->assertEquals($utf8str, $this->credis->get('utf8'));
 
         // Array
@@ -86,12 +86,12 @@ class CredisTest extends CredisTestCommon
         $this->assertTrue(in_array('', $mGet));
 
         // Non-array
-        $mGet = $this->credis->mGet('foo','bar');
+        $mGet = $this->credis->mGet('foo', 'bar');
         $this->assertTrue(in_array('FOO', $mGet));
         $this->assertTrue(in_array('BAR', $mGet));
 
         // Delete strings, null response
-        $this->assertEquals(2, $this->credis->del('foo','bar'));
+        $this->assertEquals(2, $this->credis->del('foo', 'bar'));
         $this->assertFalse($this->credis->get('foo'));
         $this->assertFalse($this->credis->get('bar'));
 
@@ -214,7 +214,7 @@ class CredisTest extends CredisTestCommon
         $this->assertTrue(array_key_exists('And', $range));
         $this->assertEquals(10, $range['And']);
 
-        $range = $this->credis->zRevRangeByScore('myset', '+inf',10, array('withscores' => true));
+        $range = $this->credis->zRevRangeByScore('myset', '+inf', 10, array('withscores' => true));
         $this->assertEquals(2, count($range));
         $this->assertTrue(array_key_exists('And', $range));
         $this->assertEquals(10, $range['And']);
@@ -267,12 +267,12 @@ class CredisTest extends CredisTestCommon
 
     public function testHashes()
     {
-        $this->assertEquals(1, $this->credis->hSet('hash','field1','foo'));
-        $this->assertEquals(0, $this->credis->hSet('hash','field1','foo'));
-        $this->assertEquals('foo', $this->credis->hGet('hash','field1'));
-        $this->assertEquals(NULL, $this->credis->hGet('hash','x'));
+        $this->assertEquals(1, $this->credis->hSet('hash', 'field1', 'foo'));
+        $this->assertEquals(0, $this->credis->hSet('hash', 'field1', 'foo'));
+        $this->assertEquals('foo', $this->credis->hGet('hash', 'field1'));
+        $this->assertEquals(null, $this->credis->hGet('hash', 'x'));
         $this->assertTrue($this->credis->hMSet('hash', array('field2' => 'Hello', 'field3' => 'World')));
-        $this->assertEquals(array('field1' => 'foo', 'field2' => 'Hello', 'nilfield' => FALSE), $this->credis->hMGet('hash', array('field1','field2','nilfield')));
+        $this->assertEquals(array('field1' => 'foo', 'field2' => 'Hello', 'nilfield' => false), $this->credis->hMGet('hash', array('field1','field2','nilfield')));
         $this->assertEquals(array(), $this->credis->hGetAll('nohash'));
         $this->assertEquals(array('field1' => 'foo', 'field2' => 'Hello', 'field3' => 'World'), $this->credis->hGetAll('hash'));
 
@@ -290,11 +290,11 @@ class CredisTest extends CredisTestCommon
 
         $this->credis->pipeline();
         $this->assertTrue($this->credis === $this->credis->hMGet('hash', array('field1','field2','nilfield')));
-        $this->assertEquals(array(0 => array('field1' => 'foo', 'field2' => 'Hello', 'nilfield' => FALSE)), $this->credis->exec());
+        $this->assertEquals(array(0 => array('field1' => 'foo', 'field2' => 'Hello', 'nilfield' => false)), $this->credis->exec());
 
         $this->credis->pipeline()->multi();
         $this->assertTrue($this->credis === $this->credis->hMGet('hash', array('field1','field2','nilfield')));
-        $this->assertEquals(array(0 => array('field1' => 'foo', 'field2' => 'Hello', 'nilfield' => FALSE)), $this->credis->exec());
+        $this->assertEquals(array(0 => array('field1' => 'foo', 'field2' => 'Hello', 'nilfield' => false)), $this->credis->exec());
     }
 
     public function testFalsey()
@@ -335,7 +335,8 @@ class CredisTest extends CredisTestCommon
             array(
                 true,
                 true,
-            ), $reply
+            ),
+            $reply
         );
         $this->assertTrue($this->credis->unwatch());
     }
@@ -425,7 +426,8 @@ class CredisTest extends CredisTestCommon
                     'member3' => 3.0,
                     'member2' => 2.0,
                 ),
-            ), $reply
+            ),
+            $reply
         );
     }
 
@@ -454,7 +456,7 @@ class CredisTest extends CredisTestCommon
                 ->lpop('a')
                 ->exec();
         $this->assertEquals(2, count($reply));
-        $this->assertEquals(TRUE, $reply[0]);
+        $this->assertEquals(true, $reply[0]);
         $this->assertFalse($reply[1]);
     }
 
@@ -471,7 +473,7 @@ class CredisTest extends CredisTestCommon
         $this->assertEquals('09d3822de862f46d784e6a36848b4f0736dda47a', $this->credis->script('load', 'return 3'));
         $this->assertEquals(3, $this->credis->evalSha('09d3822de862f46d784e6a36848b4f0736dda47a'));
 
-        $this->credis->set('foo','FOO');
+        $this->credis->set('foo', 'FOO');
         $this->assertEquals('FOOBAR', $this->credis->eval("return redis.call('get', KEYS[1])..ARGV[1]", 'foo', 'BAR'));
 
         $this->assertEquals(array(1,2,'three'), $this->credis->eval("return {1,2,'three'}"));
@@ -539,7 +541,7 @@ class CredisTest extends CredisTestCommon
       if ($this->useStandalone) {
           $this->credis->forceStandalone();
       }
-      $this->assertTrue($this->credis->set('database',1));
+      $this->assertTrue($this->credis->set('database', 1));
       $this->credis->close();
       $this->credis = new Credis_Client($this->redisConfig[0]['host'], $this->redisConfig[0]['port'], $this->redisConfig[0]['timeout'], false, 0);
       if ($this->useStandalone) {
@@ -550,7 +552,7 @@ class CredisTest extends CredisTestCommon
       if ($this->useStandalone) {
           $this->credis->forceStandalone();
       }
-      $this->assertEquals(1,$this->credis->get('database'));
+      $this->assertEquals(1, $this->credis->get('database'));
   }
 
   /**
@@ -559,32 +561,26 @@ class CredisTest extends CredisTestCommon
   public function testPassword()
   {
       $this->tearDown();
-      $this->assertArrayHasKey('password',$this->redisConfig[4]);
+      $this->assertArrayHasKey('password', $this->redisConfig[4]);
       $this->credis = new Credis_Client($this->redisConfig[4]['host'], $this->redisConfig[4]['port'], $this->redisConfig[4]['timeout'], false, 0, $this->redisConfig[4]['password']);
       if ($this->useStandalone) {
           $this->credis->forceStandalone();
       }
-      $this->assertInstanceOf('Credis_Client',$this->credis->connect());
-      $this->assertTrue($this->credis->set('key','value'));
+      $this->assertInstanceOf('Credis_Client', $this->credis->connect());
+      $this->assertTrue($this->credis->set('key', 'value'));
       $this->credis->close();
       $this->credis = new Credis_Client($this->redisConfig[4]['host'], $this->redisConfig[4]['port'], $this->redisConfig[4]['timeout'], false, 0, 'wrongpassword');
       if ($this->useStandalone) {
           $this->credis->forceStandalone();
       }
-      try
-      {
+      try {
           $this->credis->connect();
           $this->fail('connect should fail with wrong password');
-      }
-      catch(CredisException $e)
-      {
-          if (strpos($e->getMessage(), 'username') !== false)
-          {
-            $this->assertStringStartsWith('WRONGPASS invalid username-password pair', $e->getMessage());
-          }
-          else
-          {
-            $this->assertStringStartsWith('ERR invalid password', $e->getMessage());
+      } catch(CredisException $e) {
+          if (strpos($e->getMessage(), 'username') !== false) {
+              $this->assertStringStartsWith('WRONGPASS invalid username-password pair', $e->getMessage());
+          } else {
+              $this->assertStringStartsWith('ERR invalid password', $e->getMessage());
           }
 
           $this->credis->close();
@@ -593,31 +589,22 @@ class CredisTest extends CredisTestCommon
       if ($this->useStandalone) {
           $this->credis->forceStandalone();
       }
-      try
-      {
+      try {
           $this->credis->set('key', 'value');
-      }
-      catch(CredisException $e)
-      {
+      } catch(CredisException $e) {
           $this->assertStringStartsWith('NOAUTH Authentication required', $e->getMessage());
       }
-      try
-      {
+      try {
           $this->credis->auth('anotherwrongpassword');
-      }
-      catch(CredisException $e)
-      {
-        if (strpos($e->getMessage(), 'username') !== false)
-        {
-          $this->assertStringStartsWith('WRONGPASS invalid username-password pair', $e->getMessage());
-        }
-        else
-        {
-          $this->assertStringStartsWith('ERR invalid password', $e->getMessage());
-        }
+      } catch(CredisException $e) {
+          if (strpos($e->getMessage(), 'username') !== false) {
+              $this->assertStringStartsWith('WRONGPASS invalid username-password pair', $e->getMessage());
+          } else {
+              $this->assertStringStartsWith('ERR invalid password', $e->getMessage());
+          }
       }
       $this->assertTrue($this->credis->auth('thepassword'));
-      $this->assertTrue($this->credis->set('key','value'));
+      $this->assertTrue($this->credis->set('key', 'value'));
   }
 
   /**
@@ -626,32 +613,26 @@ class CredisTest extends CredisTestCommon
   public function testUsernameAndPassword()
   {
       $this->tearDown();
-      $this->assertArrayHasKey('password',$this->redisConfig[7]);
+      $this->assertArrayHasKey('password', $this->redisConfig[7]);
       $this->credis = new Credis_Client($this->redisConfig[7]['host'], $this->redisConfig[7]['port'], $this->redisConfig[7]['timeout'], false, 0, $this->redisConfig[7]['password'], $this->redisConfig[7]['username']);
       if ($this->useStandalone) {
           $this->credis->forceStandalone();
       }
-      $this->assertInstanceOf('Credis_Client',$this->credis->connect());
-      $this->assertTrue($this->credis->set('key','value'));
+      $this->assertInstanceOf('Credis_Client', $this->credis->connect());
+      $this->assertTrue($this->credis->set('key', 'value'));
       $this->credis->close();
       $this->credis = new Credis_Client($this->redisConfig[7]['host'], $this->redisConfig[7]['port'], $this->redisConfig[7]['timeout'], false, 0, 'wrongpassword', $this->redisConfig[7]['username']);
       if ($this->useStandalone) {
           $this->credis->forceStandalone();
       }
-      try
-      {
+      try {
           $this->credis->connect();
           $this->fail('connect should fail with wrong password');
-      }
-      catch(CredisException $e)
-      {
-          if (strpos($e->getMessage(), 'username') !== false)
-          {
-            $this->assertStringStartsWith('WRONGPASS invalid username-password pair', $e->getMessage());
-          }
-          else
-          {
-            $this->assertStringStartsWith('ERR invalid password', $e->getMessage());
+      } catch(CredisException $e) {
+          if (strpos($e->getMessage(), 'username') !== false) {
+              $this->assertStringStartsWith('WRONGPASS invalid username-password pair', $e->getMessage());
+          } else {
+              $this->assertStringStartsWith('ERR invalid password', $e->getMessage());
           }
 
           $this->credis->close();
@@ -660,40 +641,31 @@ class CredisTest extends CredisTestCommon
       if ($this->useStandalone) {
           $this->credis->forceStandalone();
       }
-      try
-      {
+      try {
           $this->credis->set('key', 'value');
-      }
-      catch(CredisException $e)
-      {
+      } catch(CredisException $e) {
           $this->assertStringStartsWith('NOAUTH Authentication required', $e->getMessage());
       }
-      try
-      {
+      try {
           $this->credis->auth('anotherwrongpassword');
-      }
-      catch(CredisException $e)
-      {
-        if (strpos($e->getMessage(), 'username') !== false)
-        {
-          $this->assertStringStartsWith('WRONGPASS invalid username-password pair', $e->getMessage());
-        }
-        else
-        {
-          $this->assertStringStartsWith('ERR invalid password', $e->getMessage());
-        }
+      } catch(CredisException $e) {
+          if (strpos($e->getMessage(), 'username') !== false) {
+              $this->assertStringStartsWith('WRONGPASS invalid username-password pair', $e->getMessage());
+          } else {
+              $this->assertStringStartsWith('ERR invalid password', $e->getMessage());
+          }
       }
       $this->assertTrue($this->credis->auth('thepassword'));
-      $this->assertTrue($this->credis->set('key','value'));
+      $this->assertTrue($this->credis->set('key', 'value'));
   }
 
   public function testGettersAndSetters()
   {
-      $this->assertEquals($this->credis->getHost(),$this->redisConfig[0]['host']);
-      $this->assertEquals($this->credis->getPort(),$this->redisConfig[0]['port']);
-      $this->assertEquals($this->credis->getSelectedDb(),0);
+      $this->assertEquals($this->credis->getHost(), $this->redisConfig[0]['host']);
+      $this->assertEquals($this->credis->getPort(), $this->redisConfig[0]['port']);
+      $this->assertEquals($this->credis->getSelectedDb(), 0);
       $this->assertTrue($this->credis->select(2));
-      $this->assertEquals($this->credis->getSelectedDb(),2);
+      $this->assertEquals($this->credis->getSelectedDb(), 2);
       $this->assertTrue($this->credis->isConnected());
       $this->credis->close();
       $this->assertFalse($this->credis->isConnected());
@@ -701,16 +673,16 @@ class CredisTest extends CredisTestCommon
       if ($this->useStandalone) {
           $this->credis->forceStandalone();
       }
-      $this->assertEquals('persistenceId',$this->credis->getPersistence());
+      $this->assertEquals('persistenceId', $this->credis->getPersistence());
       $this->credis = new Credis_Client('localhost', 12345);
       if ($this->useStandalone) {
           $this->credis->forceStandalone();
       }
       $this->credis->setMaxConnectRetries(1);
       if ($this->useStandalone) {
-        $this->setExpectedExceptionShim('CredisException','Connection to Redis standalone tcp://localhost:12345 failed after 2 failures.');
+          $this->setExpectedExceptionShim('CredisException', 'Connection to Redis standalone tcp://localhost:12345 failed after 2 failures.');
       } else {
-        $this->setExpectedExceptionShim('CredisException','Connection to Redis tcp://localhost:12345 failed after 2 failures.');
+          $this->setExpectedExceptionShim('CredisException', 'Connection to Redis tcp://localhost:12345 failed after 2 failures.');
       }
       $this->credis->connect();
   }
@@ -718,60 +690,60 @@ class CredisTest extends CredisTestCommon
   public function testConnectionStrings()
   {
       $this->credis = new Credis_Client('tcp://'.$this->redisConfig[0]['host'] . ':' . $this->redisConfig[0]['port']);
-      $this->assertEquals($this->credis->getHost(),$this->redisConfig[0]['host']);
-      $this->assertEquals($this->credis->getPort(),$this->redisConfig[0]['port']);
+      $this->assertEquals($this->credis->getHost(), $this->redisConfig[0]['host']);
+      $this->assertEquals($this->credis->getPort(), $this->redisConfig[0]['port']);
       $this->credis = new Credis_Client('tcp://'.$this->redisConfig[0]['host']);
-      $this->assertEquals($this->credis->getPort(),6379);
+      $this->assertEquals($this->credis->getPort(), 6379);
       $this->credis = new Credis_Client('tcp://'.$this->redisConfig[0]['host'] . ':' . $this->redisConfig[0]['port'] . '/abc123');
-      $this->assertEquals($this->credis->getPersistence(),'abc123');
-      $this->credis = new Credis_Client('tcp://'.$this->redisConfig[0]['host'],6380);
-      $this->assertEquals($this->credis->getPort(),6380);
-      $this->credis = new Credis_Client('tcp://'.$this->redisConfig[0]['host'],NULL,NULL,"abc123");
-      $this->assertEquals($this->credis->getPersistence(),'abc123');
+      $this->assertEquals($this->credis->getPersistence(), 'abc123');
+      $this->credis = new Credis_Client('tcp://'.$this->redisConfig[0]['host'], 6380);
+      $this->assertEquals($this->credis->getPort(), 6380);
+      $this->credis = new Credis_Client('tcp://'.$this->redisConfig[0]['host'], null, null, "abc123");
+      $this->assertEquals($this->credis->getPersistence(), 'abc123');
   }
 
   public function testConnectionStringsTls()
   {
-      foreach(['ssl','tls','tlsv1.0','tlsv1.1','tlsv1.2'] as $prefix){
-        $this->credis = new Credis_Client($prefix.'://'.$this->redisConfig[0]['host'] . ':' . $this->redisConfig[0]['port']);
-        $this->assertEquals($this->credis->getHost(),$this->redisConfig[0]['host']);
-        $this->assertEquals($this->credis->getPort(),$this->redisConfig[0]['port']);
-        $this->assertTrue($this->credis->isTls());
-        $this->credis = new Credis_Client($prefix.'://'.$this->redisConfig[0]['host']);
-        $this->assertEquals($this->credis->getPort(),6379);
-        $this->assertTrue($this->credis->isTls());
-        $this->credis = new Credis_Client($prefix.'://'.$this->redisConfig[0]['host'] . ':' . $this->redisConfig[0]['port'] . '/abc123');
-        $this->assertEquals($this->credis->getPersistence(),'abc123');
-        $this->assertTrue($this->credis->isTls());
-        $this->credis = new Credis_Client($prefix.'://'.$this->redisConfig[0]['host'],6380);
-        $this->assertEquals($this->credis->getPort(),6380);
-        $this->assertTrue($this->credis->isTls());
-        $this->credis = new Credis_Client($prefix.'://'.$this->redisConfig[0]['host'],NULL,NULL,"abc123");
-        $this->assertEquals($this->credis->getPersistence(),'abc123');
-        $this->assertTrue($this->credis->isTls());
+      foreach (['ssl','tls','tlsv1.0','tlsv1.1','tlsv1.2'] as $prefix) {
+          $this->credis = new Credis_Client($prefix.'://'.$this->redisConfig[0]['host'] . ':' . $this->redisConfig[0]['port']);
+          $this->assertEquals($this->credis->getHost(), $this->redisConfig[0]['host']);
+          $this->assertEquals($this->credis->getPort(), $this->redisConfig[0]['port']);
+          $this->assertTrue($this->credis->isTls());
+          $this->credis = new Credis_Client($prefix.'://'.$this->redisConfig[0]['host']);
+          $this->assertEquals($this->credis->getPort(), 6379);
+          $this->assertTrue($this->credis->isTls());
+          $this->credis = new Credis_Client($prefix.'://'.$this->redisConfig[0]['host'] . ':' . $this->redisConfig[0]['port'] . '/abc123');
+          $this->assertEquals($this->credis->getPersistence(), 'abc123');
+          $this->assertTrue($this->credis->isTls());
+          $this->credis = new Credis_Client($prefix.'://'.$this->redisConfig[0]['host'], 6380);
+          $this->assertEquals($this->credis->getPort(), 6380);
+          $this->assertTrue($this->credis->isTls());
+          $this->credis = new Credis_Client($prefix.'://'.$this->redisConfig[0]['host'], null, null, "abc123");
+          $this->assertEquals($this->credis->getPersistence(), 'abc123');
+          $this->assertTrue($this->credis->isTls());
       }
   }
 
   public function testTLSConnection()
   {
-    /**
-    https://www.php.net/manual/en/context.ssl.php
-    > Oddly, if "tls://" is set below, then TLSv1 is forced, but using "ssl://" allows TLSv1.2
+      /**
+      https://www.php.net/manual/en/context.ssl.php
+      > Oddly, if "tls://" is set below, then TLSv1 is forced, but using "ssl://" allows TLSv1.2
 
-    and
-    >Recommended use "ssl://" transport.
-    > in php 5.5 ~ 7.1
-    > ssl:// transport = ssl_v2|ssl_v3|tls_v1.0|tls_v1.1|tls_v1.2
-    > tls:// transport = tls_v1.0
-    > after 7.2 ssl:// and tls:// transports is same
-    > php 7.2 ~ 7.3 = tls_v1.0|tls_v1.1|tls_v1.2
-    > php 7.4 ~ 8.1 = tls_v1.0|tls_v1.1|tls_v1.2|tls_v1.3
-     */
+      and
+      >Recommended use "ssl://" transport.
+      > in php 5.5 ~ 7.1
+      > ssl:// transport = ssl_v2|ssl_v3|tls_v1.0|tls_v1.1|tls_v1.2
+      > tls:// transport = tls_v1.0
+      > after 7.2 ssl:// and tls:// transports is same
+      > php 7.2 ~ 7.3 = tls_v1.0|tls_v1.1|tls_v1.2
+      > php 7.4 ~ 8.1 = tls_v1.0|tls_v1.1|tls_v1.2|tls_v1.3
+       */
 
-    $this->credis = new Credis_Client('ssl://'.$this->redisConfig[8]['host'] . ':' . $this->redisConfig[8]['port']);
-    $this->credis->setTlsOptions((array)$this->redisConfig[8]['ssl']);
-    $this->credis->connect();
-    $this->assertTrue(true);
+      $this->credis = new Credis_Client('ssl://'.$this->redisConfig[8]['host'] . ':' . $this->redisConfig[8]['port']);
+      $this->credis->setTlsOptions((array)$this->redisConfig[8]['ssl']);
+      $this->credis->connect();
+      $this->assertTrue(true);
   }
 
   /**
@@ -785,14 +757,14 @@ class CredisTest extends CredisTestCommon
       }
       $this->credis->connect();
       $this->assertTrue($this->credis->isConnected());
-      $this->credis->set('key','value');
-      $this->assertEquals('value',$this->credis->get('key'));
+      $this->credis->set('key', 'value');
+      $this->assertEquals('value', $this->credis->get('key'));
   }
 
   public function testInvalidTcpConnectionString()
   {
       $this->credis->close();
-      $this->setExpectedExceptionShim('CredisException','Invalid host format; expected tcp://host[:port][/persistence_identifier]');
+      $this->setExpectedExceptionShim('CredisException', 'Invalid host format; expected tcp://host[:port][/persistence_identifier]');
       $this->credis = new Credis_Client('tcp://'.$this->redisConfig[0]['host'] . ':abc');
       if ($this->useStandalone) {
           $this->credis->forceStandalone();
@@ -802,7 +774,7 @@ class CredisTest extends CredisTestCommon
   public function testInvalidTlsConnectionString()
   {
       $this->credis->close();
-      $this->setExpectedExceptionShim('CredisException','Invalid host format; expected tls://host[:port][/persistence_identifier]');
+      $this->setExpectedExceptionShim('CredisException', 'Invalid host format; expected tls://host[:port][/persistence_identifier]');
       $this->credis = new Credis_Client('tls://'.$this->redisConfig[0]['host'] . ':abc');
       if ($this->useStandalone) {
           $this->credis->forceStandalone();
@@ -815,7 +787,7 @@ class CredisTest extends CredisTestCommon
   public function testInvalidUnixSocketConnectionString()
   {
       $this->credis->close();
-      $this->setExpectedExceptionShim('CredisException','Invalid unix socket format; expected unix:///path/to/redis.sock');
+      $this->setExpectedExceptionShim('CredisException', 'Invalid unix socket format; expected unix:///path/to/redis.sock');
       $this->credis = new Credis_Client('unix://path/to/redis.sock');
       if ($this->useStandalone) {
           $this->credis->forceStandalone();
@@ -825,75 +797,67 @@ class CredisTest extends CredisTestCommon
   public function testForceStandAloneAfterEstablishedConnection()
   {
       $this->credis->connect();
-      if ( ! $this->useStandalone) {
-          $this->setExpectedExceptionShim('CredisException','Cannot force Credis_Client to use standalone PHP driver after a connection has already been established.');
+      if (! $this->useStandalone) {
+          $this->setExpectedExceptionShim('CredisException', 'Cannot force Credis_Client to use standalone PHP driver after a connection has already been established.');
       }
       $this->credis->forceStandalone();
       $this->assertTrue(true);
   }
   public function testHscan()
   {
-      $this->credis->hmset('hash',array('name' => 'Jack','age' =>33));
+      $this->credis->hmset('hash', array('name' => 'Jack','age' =>33));
       $iterator = null;
-      $result = $this->credis->hscan($iterator,'hash','n*',10);
-      $this->assertEquals($iterator,0);
-      $this->assertEquals($result,['name'=>'Jack']);
-	}
+      $result = $this->credis->hscan($iterator, 'hash', 'n*', 10);
+      $this->assertEquals($iterator, 0);
+      $this->assertEquals($result, ['name'=>'Jack']);
+  }
     public function testSscan()
     {
-        $this->credis->sadd('set','name','Jack');
-        $this->credis->sadd('set','age','33');
+        $this->credis->sadd('set', 'name', 'Jack');
+        $this->credis->sadd('set', 'age', '33');
         $iterator = null;
-        $result = $this->credis->sscan($iterator,'set','n*',10);
-        $this->assertEquals($iterator,0);
-        $this->assertEquals($result,[0=>'name']);
+        $result = $this->credis->sscan($iterator, 'set', 'n*', 10);
+        $this->assertEquals($iterator, 0);
+        $this->assertEquals($result, [0=>'name']);
     }
     public function testZscan()
     {
-        $this->credis->zadd('sortedset',0,'name');
-        $this->credis->zadd('sortedset',1,'age');
+        $this->credis->zadd('sortedset', 0, 'name');
+        $this->credis->zadd('sortedset', 1, 'age');
         $iterator = null;
-        $result = $this->credis->zscan($iterator,'sortedset','n*',10);
-        $this->assertEquals($iterator,0);
-        $this->assertEquals($result,['name'=>'0']);
+        $result = $this->credis->zscan($iterator, 'sortedset', 'n*', 10);
+        $this->assertEquals($iterator, 0);
+        $this->assertEquals($result, ['name'=>'0']);
     }
     public function testscan()
     {
         $seen = array();
-        for($i = 0; $i < 100; $i++)
-        {
+        for ($i = 0; $i < 100; $i++) {
             $this->credis->set('name.' . $i, 'Jack');
             $this->credis->set('age.' . $i, '33');
         }
         $iterator = null;
-        do
-        {
+        do {
             $result = $this->credis->scan($iterator, 'n*', 10);
-            if ($result === false)
-            {
+            if ($result === false) {
                 $this->assertEquals($iterator, 0);
                 break;
-            }
-            else
-            {
-                foreach($result as $key)
-                {
+            } else {
+                foreach ($result as $key) {
                     $seen[$key] = true;
                 }
             }
-        }
-        while($iterator);
+        } while ($iterator);
         $this->assertEquals(count($seen), 100);
     }
 
   public function testPing()
   {
-    $pong = $this->credis->ping();
-    $this->assertEquals("PONG",$pong);
-    if (version_compare(phpversion('redis'), '5.0.0', '>='))
-    {
-      $pong = $this->credis->ping("test");
-      $this->assertEquals("test", $pong);
-    }
+      $pong = $this->credis->ping();
+      $this->assertEquals("PONG", $pong);
+      if (version_compare(phpversion('redis'), '5.0.0', '>=')) {
+          $pong = $this->credis->ping("test");
+          $this->assertEquals("test", $pong);
+      }
   }
 }

--- a/tests/CredisTestCommon.php
+++ b/tests/CredisTestCommon.php
@@ -1,13 +1,14 @@
 <?php
+
 // backward compatibility (https://stackoverflow.com/a/42828632/187780)
 if (!class_exists('\PHPUnit\Framework\TestCase') && class_exists('\PHPUnit_Framework_TestCase')) {
     class_alias('\PHPUnit_Framework_TestCase', '\PHPUnit\Framework\TestCase');
 }
 
 if (version_compare(phpversion(), '8.0.0', '>=')) {
-  include 'phpunit-shims/php8.php';
+    include 'phpunit-shims/php8.php';
 } else {
-  include 'phpunit-shims/php7.php';
+    include 'phpunit-shims/php7.php';
 }
 
 class CredisTestCommon extends CredisTestCommonShim
@@ -18,25 +19,22 @@ class CredisTestCommon extends CredisTestCommonShim
 
     protected function setUpInternal()
     {
-        if ($this->redisConfig === null)
-        {
+        if ($this->redisConfig === null) {
             $configFile = dirname(__FILE__) . '/redis_config.json';
-            if (!file_exists($configFile) || !($config = file_get_contents($configFile)))
-            {
+            if (!file_exists($configFile) || !($config = file_get_contents($configFile))) {
                 $this->markTestSkipped('Could not load ' . $configFile);
 
                 return;
             }
             $this->redisConfig = json_decode($config);
             $arrayConfig = array();
-            foreach ($this->redisConfig as $config)
-            {
+            foreach ($this->redisConfig as $config) {
                 $arrayConfig[] = (array)$config;
             }
             $this->redisConfig = $arrayConfig;
         }
 
-        if(!$this->useStandalone && !extension_loaded('redis')) {
+        if (!$this->useStandalone && !extension_loaded('redis')) {
             $this->fail('The Redis extension is not loaded.');
         }
     }
@@ -48,18 +46,14 @@ class CredisTestCommon extends CredisTestCommonShim
      */
     protected function waitForSlaveReplication()
     {
-        if ($this->slaveConfig === null)
-        {
-            foreach ($this->redisConfig as $config)
-            {
-                if ($config['alias'] === 'slave')
-                {
+        if ($this->slaveConfig === null) {
+            foreach ($this->redisConfig as $config) {
+                if ($config['alias'] === 'slave') {
                     $this->slaveConfig = $config;
                     break;
                 }
             }
-            if ($this->slaveConfig === null)
-            {
+            if ($this->slaveConfig === null) {
                 $this->markTestSkipped('Could not load slave config');
 
                 return false;
@@ -73,25 +67,20 @@ class CredisTestCommon extends CredisTestCommonShim
 
         $start = microtime(true);
         $timeout = $start + 60;
-        while (microtime(true) < $timeout)
-        {
+        while (microtime(true) < $timeout) {
             usleep(100);
             $role = $slaveConfig->role();
-            if ($role[0] !== 'slave')
-            {
+            if ($role[0] !== 'slave') {
                 $this->markTestSkipped('slave config does not points to a slave');
                 return false;
             }
-            if ($role[3] === 'connected')
-            {
+            if ($role[3] === 'connected') {
                 $masterRole = $masterConfig->role();
-                if ($masterRole[0] !== 'master')
-                {
+                if ($masterRole[0] !== 'master') {
                     $this->markTestSkipped('master config does not points to a master');
                     return false;
                 }
-                if ($role[4] >= $masterRole[1])
-                {
+                if ($role[4] >= $masterRole[1]) {
                     return true;
                 }
             }
@@ -103,7 +92,7 @@ class CredisTestCommon extends CredisTestCommonShim
 
     public static function setUpBeforeClassInternal()
     {
-        if(preg_match('/^WIN/',strtoupper(PHP_OS))){
+        if (preg_match('/^WIN/', strtoupper(PHP_OS))) {
             echo "Unit tests will not work automatically on Windows. Please setup all Redis instances manually:".PHP_EOL;
             echo "\tredis-server redis-master.conf".PHP_EOL;
             echo "\tredis-server redis-slave.conf".PHP_EOL;
@@ -115,19 +104,19 @@ class CredisTestCommon extends CredisTestCommonShim
         } else {
             chdir(__DIR__.'/../');
             if (!file_exists('./tests/tls/ca.crt') || !file_exists('./tests/tls/server.crt')) {
-              // generate SSL keys
-              system('./tests/gen-test-certs.sh');
+                // generate SSL keys
+                system('./tests/gen-test-certs.sh');
             }
             chdir(__DIR__);
             $directoryIterator = new DirectoryIterator(__DIR__);
-            foreach($directoryIterator as $item){
-                if(!$item->isfile() || !preg_match('/^redis\-(.+)\.conf$/',$item->getFilename()) || $item->getFilename() == 'redis-sentinel.conf'){
+            foreach ($directoryIterator as $item) {
+                if (!$item->isfile() || !preg_match('/^redis\-(.+)\.conf$/', $item->getFilename()) || $item->getFilename() == 'redis-sentinel.conf') {
                     continue;
                 }
                 exec('redis-server '.$item->getFilename());
             }
-            copy('redis-master.conf','redis-master.conf.bak');
-            copy('redis-slave.conf','redis-slave.conf.bak');
+            copy('redis-master.conf', 'redis-master.conf.bak');
+            copy('redis-slave.conf', 'redis-slave.conf.bak');
             // wait for redis instances to initialize
             sleep(1);
         }
@@ -135,18 +124,18 @@ class CredisTestCommon extends CredisTestCommonShim
 
     public static function tearDownAfterClassInternal()
     {
-        if(preg_match('/^WIN/',strtoupper(PHP_OS))){
+        if (preg_match('/^WIN/', strtoupper(PHP_OS))) {
             echo "Please kill all Redis instances manually:".PHP_EOL;
         } else {
             chdir(__DIR__);
             $directoryIterator = new DirectoryIterator(__DIR__);
-            foreach($directoryIterator as $item){
-                if(!$item->isfile() || !preg_match('/^redis\-(.+)\.pid$/',$item->getFilename())){
+            foreach ($directoryIterator as $item) {
+                if (!$item->isfile() || !preg_match('/^redis\-(.+)\.pid$/', $item->getFilename())) {
                     continue;
                 }
                 $pid = trim(file_get_contents($item->getFilename()));
-                if(function_exists('posix_kill')){
-                    posix_kill($pid,15);
+                if (function_exists('posix_kill')) {
+                    posix_kill($pid, 15);
                 } else {
                     exec('kill '.$pid);
                 }
@@ -155,8 +144,8 @@ class CredisTestCommon extends CredisTestCommonShim
             @unlink('dump.rdb');
             @unlink('redis-master.conf');
             @unlink('redis-slave.conf');
-            @copy('redis-master.conf.bak','redis-master.conf');
-            @copy('redis-slave.conf.bak','redis-slave.conf');
+            @copy('redis-master.conf.bak', 'redis-master.conf');
+            @copy('redis-slave.conf.bak', 'redis-slave.conf');
         }
     }
 
@@ -164,7 +153,7 @@ class CredisTestCommon extends CredisTestCommonShim
      * php 7.2 compat fix, as directly polyfilling for older PHPUnit causes a function signature compatibility issue
      * This is due to the defined return type
      */
-    public function setExpectedExceptionShim($class, $message = NULL, $code = NULL)
+    public function setExpectedExceptionShim($class, $message = null, $code = null)
     {
         if (method_exists($this, 'setExpectedException')) {
             $this->setExpectedException($class, $message, $code);

--- a/tests/phpunit-shims/php7.php
+++ b/tests/phpunit-shims/php7.php
@@ -2,27 +2,33 @@
 
 abstract class CredisTestCommonShim extends \PHPUnit\Framework\TestCase
 {
-  abstract protected function setUpInternal();
-  protected function tearDownInternal() {}
-  public static function setUpBeforeClassInternal() {}
-  public static function tearDownAfterClassInternal() {}
+    abstract protected function setUpInternal();
+    protected function tearDownInternal()
+    {
+    }
+    public static function setUpBeforeClassInternal()
+    {
+    }
+    public static function tearDownAfterClassInternal()
+    {
+    }
 
-  protected function setUp()
-  {
-    $this->setUpInternal();
-  }
-  protected function tearDown()
-  {
-    $this->tearDownInternal();
-  }
+    protected function setUp()
+    {
+        $this->setUpInternal();
+    }
+    protected function tearDown()
+    {
+        $this->tearDownInternal();
+    }
 
-  public static function setUpBeforeClass()
-  {
-    static::setUpBeforeClassInternal();
-  }
+    public static function setUpBeforeClass()
+    {
+        static::setUpBeforeClassInternal();
+    }
 
-  public static function tearDownAfterClass()
-  {
-    static::tearDownAfterClassInternal();
-  }
+    public static function tearDownAfterClass()
+    {
+        static::tearDownAfterClassInternal();
+    }
 }

--- a/tests/phpunit-shims/php8.php
+++ b/tests/phpunit-shims/php8.php
@@ -1,29 +1,36 @@
 <?php
+
 /** @noinspection PhpLanguageLevelInspection */
 
 abstract class CredisTestCommonShim extends \PHPUnit\Framework\TestCase
 {
-  abstract protected function setUpInternal();
-  protected function tearDownInternal() {}
-  public static function setUpBeforeClassInternal() {}
-  public static function tearDownAfterClassInternal() {}
+    abstract protected function setUpInternal();
+    protected function tearDownInternal()
+    {
+    }
+    public static function setUpBeforeClassInternal()
+    {
+    }
+    public static function tearDownAfterClassInternal()
+    {
+    }
 
-  protected function setUp(): void
-  {
-    $this->setUpInternal();
-  }
-  protected function tearDown(): void
-  {
-    $this->tearDownInternal();
-  }
+    protected function setUp(): void
+    {
+        $this->setUpInternal();
+    }
+    protected function tearDown(): void
+    {
+        $this->tearDownInternal();
+    }
 
-  public static function setUpBeforeClass(): void
-  {
-    static::setUpBeforeClassInternal();
-  }
+    public static function setUpBeforeClass(): void
+    {
+        static::setUpBeforeClassInternal();
+    }
 
-  public static function tearDownAfterClass(): void
-  {
-    static::tearDownAfterClassInternal();
-  }
+    public static function tearDownAfterClass(): void
+    {
+        static::tearDownAfterClassInternal();
+    }
 }


### PR DESCRIPTION
Close #173

I think the reformatting will improve the code's readability and maintainability.

* Use php-cs-fixer to re-format the code. 
* Remove unused (incorrect) consts: Credis_Client::VERSION, Credis_Client::FREAD_BLOCK_SIZE
* Update the comment of Credis_Client __construct: "Creates a Redisent connection" -> "Creates a connection" because there is no Redisent object anymore in code.


ps: feel free to edit on the PR directly

Diff without spaces: https://github.com/colinmollenhour/credis/pull/175/files?diff=split&w=1