### PR TITLE
Support `UNLINK` command

### DIFF
--- a/Client.php
+++ b/Client.php
@@ -56,7 +56,8 @@ class CredisException extends Exception
  * @method int|Credis_Client           dbsize()
  *
  * Keys:
- * @method int|Credis_Client           del(string|array $key)
+ * @method int|Credis_Client           del(string... $key)
+ * @method int|Credis_Client           unlink(string... $key)
  * @method int|Credis_Client           exists(string $key)
  * @method int|Credis_Client           expire(string $key, int $seconds)
  * @method int|Credis_Client           expireAt(string $key, int $timestamp)
@@ -1154,6 +1155,7 @@ class Credis_Client
                 case 'hmset':
                 case 'hmget':
                 case 'del':
+                case 'unlink':
                 case 'zrangebyscore':
                 case 'zrevrangebyscore':
                     break;

--- a/tests/CredisTest.php
+++ b/tests/CredisTest.php
@@ -80,7 +80,7 @@ class CredisTest extends CredisTestCommon
 
         // Array
         $this->assertTrue($this->credis->mSet(array('bar' => 'BAR', 'apple' => 'red')));
-        $mGet = $this->credis->mGet(array('foo','bar','empty'));
+        $mGet = $this->credis->mGet(array('foo', 'bar', 'empty'));
         $this->assertTrue(in_array('FOO', $mGet));
         $this->assertTrue(in_array('BAR', $mGet));
         $this->assertTrue(in_array('', $mGet));
@@ -94,6 +94,13 @@ class CredisTest extends CredisTestCommon
         $this->assertEquals(2, $this->credis->del('foo', 'bar'));
         $this->assertFalse($this->credis->get('foo'));
         $this->assertFalse($this->credis->get('bar'));
+
+        // Unlink keys
+        $this->assertTrue($this->credis->mSet(array('t1' => 'a', 't2' => 'b', 't3' => 'c')));
+        $this->assertEquals(2, $this->credis->unlink('t1', 't2'));
+        $this->assertFalse($this->credis->get('t1'));
+        $this->assertFalse($this->credis->get('t2'));
+        $this->assertEquals('c', $this->credis->get('t3'));
 
         // Long string
         $longString = str_repeat(md5('asd'), 4096); // 128k (redis.h REDIS_INLINE_MAX_SIZE = 64k)


### PR DESCRIPTION
Close #126 

Actually, the `credis->unlink()` should also have worked before (by general magic function). This PR just adds a hint and adds some tests.

It works like `DEL`, https://redis.io/commands/unlink/