### PR TITLE
Smooth over mget quirks between credis/phpredis modes

### DIFF
--- a/Client.php
+++ b/Client.php
@@ -1027,6 +1027,9 @@ class Credis_Client
                     if (isset($args[0]) && is_array($args[0])) {
                         $args = array_values($args[0]);
                     }
+                    if (is_array($args) && count($args) === 0) {
+                        return false;
+                    }
                     break;
                 case 'hmset':
                     if (isset($args[1]) && is_array($args[1])) {

--- a/tests/CredisTest.php
+++ b/tests/CredisTest.php
@@ -84,11 +84,17 @@ class CredisTest extends CredisTestCommon
         $this->assertTrue(in_array('FOO', $mGet));
         $this->assertTrue(in_array('BAR', $mGet));
         $this->assertTrue(in_array('', $mGet));
+        $mGet = $this->credis->mGet(array('foo'));
+        $this->assertTrue(in_array('FOO', $mGet));
+        $mGet = $this->credis->mGet(array());
+        $this->assertTrue($mGet === false);
 
         // Non-array
         $mGet = $this->credis->mGet('foo', 'bar');
         $this->assertTrue(in_array('FOO', $mGet));
         $this->assertTrue(in_array('BAR', $mGet));
+        $mGet = $this->credis->mGet('foo');
+        $this->assertTrue(in_array('FOO', $mGet));
 
         // Delete strings and check they are deleted
         $this->assertEquals(2, $this->credis->del('foo', 'bar'));


### PR DESCRIPTION
mget behaves differently between credis/phpredis when given an empty array. Smoothed that over and added a test for that.