### PR TITLE
Fixes for scan/sscan/zscan/hscan & transaction/multi handling

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+[*.php]
+charset=utf-8
+end_of_line=lf
+insert_final_newline=true
+indent_style=space
+indent_size=4

--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,6 @@
 /.travis.yml export-ignore
 /composer.lock export-ignore
 /phpunit.xml export-ignore
+*.php text eol=lf
+*.js text eol=lf
+*.md text eol=lf

--- a/Client.php
+++ b/Client.php
@@ -974,8 +974,10 @@ class Credis_Client
                     break;
                 case 'scan':
                     $trackedArgs = array(&$args[0]);
-                    if (empty($trackedArgs[0])) {
+                    if ($trackedArgs[0] === null) {
                         $trackedArgs[0] = 0;
+                    } elseif ($trackedArgs[0] === 0) {
+                        return false;
                     }
                     $eArgs = array($trackedArgs[0]);
                     if (!empty($args[1])) {
@@ -992,8 +994,10 @@ class Credis_Client
                 case 'zscan':
                 case 'hscan':
                     $trackedArgs = array(&$args[1]);
-                    if (empty($trackedArgs[0])) {
+                    if ($trackedArgs[0] === null) {
                         $trackedArgs[0] = 0;
+                    } elseif ($trackedArgs[0] === 0) {
+                        return false;
                     }
                     $eArgs = array($args[0], $trackedArgs[0]);
                     if (!empty($args[2])) {

--- a/Client.php
+++ b/Client.php
@@ -1080,6 +1080,12 @@ class Credis_Client
                         $trackedArgs = $args[1];
                     }
                     break;
+                case 'multi':
+                    // calling multi() multiple times is a no-op
+                    if ($this->isMulti) {
+                        return $this;
+                    }
+                    break;
             }
             // Flatten arguments
             $args = self::_flattenArguments($args);
@@ -1112,9 +1118,6 @@ class Credis_Client
                             $result = $this->read_reply($name, true);
                             if ($result !== null) {
                                 if ($name === 'multi') {
-                                    if ($result !== true) {
-                                        throw new CredisException('Redis cmd ('.$name.') in transaction returned unexpected return value:'.var_export($result, true));
-                                    }
                                     continue;
                                 }
                                 $result = $this->decode_reply($name, $result, $arguments);

--- a/Client.php
+++ b/Client.php
@@ -1073,7 +1073,7 @@ class Credis_Client
                     $this->isMulti = $this->usePipeline = false;
 
                     if ($isMulti) {
-                        $commandNames[] = array($name, $trackedArgs);
+                        $commandNames[] = array($name, $trackedArgs, true);
                         $commands .= self::_prepare_command(array($this->getRenamedCommand($name)));
                     }
 
@@ -1087,21 +1087,31 @@ class Credis_Client
                         $queuedResponses = array();
                         $response = array();
                         foreach ($commandNames as $command) {
-                            list($name, $arguments) = $command;
+                            list($name, $arguments, $requireDispatch) = $command;
+                            if (!$requireDispatch) {
+                                $queuedResponses[] = $command;
+                                continue;
+                            }
                             $result = $this->read_reply($name, true);
                             if ($result !== null) {
+                                if ($name === 'multi') {
+                                    if ($result !== true) {
+                                        throw new CredisException('Redis cmd ('.$name.') returned unexpected return value:'.var_export($result, true));
+                                    }
+                                    continue;
+                                }
                                 $result = $this->decode_reply($name, $result, $arguments);
+                                $response[] = $result;
                             } else {
                                 $queuedResponses[] = $command;
                             }
-                            $response[] = $result;
                         }
 
                         if ($isMulti) {
-                            $response = array_pop($response);
+                            $execResponse = array_pop($response);
                             foreach ($queuedResponses as $key => $command) {
                                 list($name, $arguments) = $command;
-                                $response[$key] = $this->decode_reply($name, $response[$key], $arguments);
+                                $response[] = $this->decode_reply($name, $execResponse[$key], $arguments);
                             }
                         }
                     } catch (CredisException $e) {
@@ -1119,7 +1129,7 @@ class Credis_Client
                         $this->isMulti = true;
                     }
                     array_unshift($args, $this->getRenamedCommand($name));
-                    $this->commandNames[] = array($name, $trackedArgs);
+                    $this->commandNames[] = array($name, $trackedArgs, true);
                     $this->commands .= self::_prepare_command($args);
                     return $this;
                 }
@@ -1128,7 +1138,9 @@ class Credis_Client
             // Start pipeline mode
             if ($name === 'pipeline') {
                 $this->usePipeline = true;
-                $this->commandNames = array();
+                if (!$this->isMulti) {
+                    $this->commandNames = [];
+                }
                 $this->commands = '';
                 return $this;
             }
@@ -1141,18 +1153,29 @@ class Credis_Client
             // Non-pipeline mode
             array_unshift($args, $this->getRenamedCommand($name));
             $command = self::_prepare_command($args);
-            $this->write_command($command);
-            $response = $this->read_reply($name);
-            $response = $this->decode_reply($name, $response, $trackedArgs);
+            // transaction mode needs to track commands
+            if ($this->isMulti && $name !== 'exec' && $name !== 'discard') {
+                $this->commandNames[] = array($name, $trackedArgs, false);
+                $this->write_command($command);
+                $response = $this->read_reply($name, true);
+                if ($response !== null) {
+                    throw new CredisException('Redis cmd ('.$name.') returned unexpected return value:'.var_export($response, true));
+                }
+            } else {
+                $this->write_command($command);
+                $response = $this->read_reply($name);
+                $response = $this->decode_reply($name, $response, $trackedArgs);
+            }
 
             // Watch mode disables reconnect so error is thrown
-            if ($name == 'watch') {
+            if ($name === 'watch') {
                 $this->isWatching = true;
             } // Transaction mode
-            elseif ($this->isMulti && ($name == 'exec' || $name == 'discard')) {
+            elseif ($this->isMulti && ($name === 'exec' || $name === 'discard')) {
                 $this->isMulti = false;
+                $this->commandNames = [];
             } // Started transaction
-            elseif ($this->isMulti || $name == 'multi') {
+            elseif ($this->isMulti || $name === 'multi') {
                 $this->isMulti = true;
                 $response = $this;
             }

--- a/Client.php
+++ b/Client.php
@@ -759,6 +759,20 @@ class Credis_Client
     }
 
     /**
+     * @param string $caller
+     * @return void
+     * @throws CredisException
+     */
+    protected function assertNotPipelineOrMulti($caller)
+    {
+        if ($this->standalone && ($this->isMulti || $this->usePipeline) ||
+            // phpredis triggers a php fatal error, so do the check before
+            !$this->standalone && ($this->redis->getMode() === Redis::MULTI || $this->redis->getMode() === Redis::PIPELINE)) {
+            throw new CredisException('multi()/pipeline() mode can not be used with '.$caller);
+        }
+    }
+
+    /**
      * @param string|array $pattern
      * @return array
      */
@@ -774,9 +788,11 @@ class Credis_Client
      * @param string $pattern
      * @param int $count
      * @return bool|array
+     * @throws CredisException
      */
     public function scan(&$Iterator, $pattern = null, $count = null)
     {
+        $this->assertNotPipelineOrMulti(__METHOD__);
         return $this->__call('scan', array(&$Iterator, $pattern, $count));
     }
 
@@ -786,9 +802,11 @@ class Credis_Client
      * @param string $pattern
      * @param int $count
      * @return bool|array
+     * @throws CredisException
      */
     public function hscan(&$Iterator, $field, $pattern = null, $count = null)
     {
+        $this->assertNotPipelineOrMulti(__METHOD__);
         return $this->__call('hscan', array($field, &$Iterator, $pattern, $count));
     }
 
@@ -798,9 +816,11 @@ class Credis_Client
      * @param string $pattern
      * @param int $Iterator
      * @return bool|array
+     * @throws CredisException
      */
     public function sscan(&$Iterator, $field, $pattern = null, $count = null)
     {
+        $this->assertNotPipelineOrMulti(__METHOD__);
         return $this->__call('sscan', array($field, &$Iterator, $pattern, $count));
     }
 
@@ -810,9 +830,11 @@ class Credis_Client
      * @param string $pattern
      * @param int $Iterator
      * @return bool|array
+     * @throws CredisException
      */
     public function zscan(&$Iterator, $field, $pattern = null, $count = null)
     {
+        $this->assertNotPipelineOrMulti(__METHOD__);
         return $this->__call('zscan', array($field, &$Iterator, $pattern, $count));
     }
 

--- a/Client.php
+++ b/Client.php
@@ -1070,6 +1070,7 @@ class Credis_Client
                     $commandNames = $this->commandNames;
                     $commands = $this->commands;
                     $this->commands = $this->commandNames = null;
+                    $this->isMulti = $this->usePipeline = false;
 
                     if ($isMulti) {
                         $commandNames[] = array($name, $trackedArgs);

--- a/Client.php
+++ b/Client.php
@@ -953,6 +953,7 @@ class Credis_Client
 
         // Send request via native PHP
         if ($this->standalone) {
+            // Early returns should verify how phpredis behaves!
             $trackedArgs = array();
             switch ($name) {
                 case 'eval':
@@ -1054,7 +1055,7 @@ class Credis_Client
                         $args = array_values($args[0]);
                     }
                     if (is_array($args) && count($args) === 0) {
-                        return false;
+                        return ($this->isMulti || $this->usePipeline) ? $this : false;
                     }
                     break;
                 case 'hmset':

--- a/Client.php
+++ b/Client.php
@@ -770,7 +770,7 @@ class Credis_Client
     }
 
     /**
-     * @param int $Iterator
+     * @param ?int $Iterator
      * @param string $pattern
      * @param int $count
      * @return bool|array
@@ -781,7 +781,7 @@ class Credis_Client
     }
 
     /**
-     * @param int $Iterator
+     * @param ?int $Iterator
      * @param string $field
      * @param string $pattern
      * @param int $count
@@ -793,7 +793,7 @@ class Credis_Client
     }
 
     /**
-     * @param int $Iterator
+     * @param ?int $Iterator
      * @param string $field
      * @param string $pattern
      * @param int $Iterator
@@ -805,7 +805,7 @@ class Credis_Client
     }
 
     /**
-     * @param int $Iterator
+     * @param ?int $Iterator
      * @param string $field
      * @param string $pattern
      * @param int $Iterator

--- a/tests/CredisTest.php
+++ b/tests/CredisTest.php
@@ -487,7 +487,15 @@ class CredisTest extends CredisTestCommon
 
         $reply = $this->credis->multi()
                               ->set('a', 3)
-                              ->lpop('a')
+                              ->lpop('a') // bad operation for "a"'s type
+                              ->exec();
+        $this->assertEquals(2, count($reply));
+        $this->assertEquals(true, $reply[0]);
+        $this->assertFalse($reply[1]);
+
+        $reply = $this->credis->multi()->pipeline()
+                              ->set('a', 3)
+                              ->lpop('a') // bad operation for "a"'s type
                               ->exec();
         $this->assertEquals(2, count($reply));
         $this->assertEquals(true, $reply[0]);

--- a/tests/CredisTest.php
+++ b/tests/CredisTest.php
@@ -444,27 +444,43 @@ class CredisTest extends CredisTestCommon
     public function testTransaction()
     {
         $reply = $this->credis->multi()
-                ->incr('foo')
-                ->incr('bar')
-                ->exec();
+                              ->incr('foo')
+                              ->incr('bar')
+                              ->exec();
         $this->assertEquals(array(1,1), $reply);
 
         $reply = $this->credis->pipeline()->multi()
-                ->incr('foo')
-                ->incr('bar')
-                ->exec();
+                              ->incr('foo')
+                              ->incr('bar')
+                              ->exec();
         $this->assertEquals(array(2,2), $reply);
 
+        $reply = $this->credis->pipeline()
+                              ->incr('foo')
+                              ->multi()
+                              ->incr('foo')
+                              ->incr('bar')
+                              ->exec();
+        $this->assertEquals(array(3,4,3), $reply);
+
         $reply = $this->credis->multi()->pipeline()
-                ->incr('foo')
-                ->incr('bar')
-                ->exec();
-        $this->assertEquals(array(3,3), $reply);
+                              ->incr('foo')
+                              ->incr('bar')
+                              ->exec();
+        $this->assertEquals(array(5,4), $reply);
 
         $reply = $this->credis->multi()
-                ->set('a', 3)
-                ->lpop('a')
-                ->exec();
+                              ->incr('foo')
+                              ->pipeline()
+                              ->incr('foo')
+                              ->incr('bar')
+                              ->exec();
+        $this->assertEquals(array(6,7,5), $reply);
+
+        $reply = $this->credis->multi()
+                              ->set('a', 3)
+                              ->lpop('a')
+                              ->exec();
         $this->assertEquals(2, count($reply));
         $this->assertEquals(true, $reply[0]);
         $this->assertFalse($reply[1]);

--- a/tests/CredisTest.php
+++ b/tests/CredisTest.php
@@ -845,7 +845,7 @@ class CredisTest extends CredisTestCommon
     {
         $this->credis->sadd('set', 'foo', 'bar');
         $iterator = 0;
-        $result = $this->credis->zscan($iterator, 'set','*', 10);
+        $result = $this->credis->zscan($iterator, 'set', '*', 10);
         $this->assertEquals($iterator, 0);
         $this->assertEquals($result, false);
     }
@@ -864,7 +864,7 @@ class CredisTest extends CredisTestCommon
     {
         $this->credis->zadd('sortedset', 0, 'name');
         $iterator = 0;
-        $result = $this->credis->zscan($iterator, 'sortedset','*', 10);
+        $result = $this->credis->zscan($iterator, 'sortedset', '*', 10);
         $this->assertEquals($iterator, 0);
         $this->assertEquals($result, false);
     }

--- a/tests/CredisTest.php
+++ b/tests/CredisTest.php
@@ -821,6 +821,16 @@ class CredisTest extends CredisTestCommon
       $this->assertEquals($iterator, 0);
       $this->assertEquals($result, ['name'=>'Jack']);
   }
+
+    public function testHscanEmptyIterator()
+    {
+      $this->credis->hmset('set', ['foo' => 'bar']);
+      $iterator = 0;
+      $result = $this->credis->zscan($iterator, 'hash','*', 10);
+      $this->assertEquals($iterator, 0);
+      $this->assertEquals($result, false);
+    }
+
     public function testSscan()
     {
         $this->credis->sadd('set', 'name', 'Jack');
@@ -830,6 +840,16 @@ class CredisTest extends CredisTestCommon
         $this->assertEquals($iterator, 0);
         $this->assertEquals($result, [0=>'name']);
     }
+
+    public function testSscanEmptyIterator()
+    {
+      $this->credis->sadd('set', 'foo', 'bar');
+      $iterator = 0;
+      $result = $this->credis->zscan($iterator, 'set','*', 10);
+      $this->assertEquals($iterator, 0);
+      $this->assertEquals($result, false);
+    }
+
     public function testZscan()
     {
         $this->credis->zadd('sortedset', 0, 'name');
@@ -839,6 +859,16 @@ class CredisTest extends CredisTestCommon
         $this->assertEquals($iterator, 0);
         $this->assertEquals($result, ['name'=>'0']);
     }
+
+    public function testZscanEmptyIterator()
+    {
+      $this->credis->zadd('sortedset', 0, 'name');
+      $iterator = 0;
+      $result = $this->credis->zscan($iterator, 'sortedset','*', 10);
+      $this->assertEquals($iterator, 0);
+      $this->assertEquals($result, false);
+    }
+
     public function testscan()
     {
         $seen = array();
@@ -859,6 +889,15 @@ class CredisTest extends CredisTestCommon
             }
         } while ($iterator);
         $this->assertEquals(count($seen), 100);
+    }
+
+    public function testscanEmptyIterator()
+    {
+      $this->credis->set('foo', 'bar');
+      $iterator = 0;
+      $result = $this->credis->scan($iterator, '*', 10);
+      $this->assertEquals($iterator, 0);
+      $this->assertEquals($result, false);
     }
 
   public function testPing()

--- a/tests/CredisTest.php
+++ b/tests/CredisTest.php
@@ -824,11 +824,11 @@ class CredisTest extends CredisTestCommon
 
     public function testHscanEmptyIterator()
     {
-      $this->credis->hmset('set', ['foo' => 'bar']);
-      $iterator = 0;
-      $result = $this->credis->zscan($iterator, 'hash','*', 10);
-      $this->assertEquals($iterator, 0);
-      $this->assertEquals($result, false);
+        $this->credis->hmset('set', ['foo' => 'bar']);
+        $iterator = 0;
+        $result = $this->credis->zscan($iterator, 'hash', '*', 10);
+        $this->assertEquals($iterator, 0);
+        $this->assertEquals($result, false);
     }
 
     public function testSscan()
@@ -843,11 +843,11 @@ class CredisTest extends CredisTestCommon
 
     public function testSscanEmptyIterator()
     {
-      $this->credis->sadd('set', 'foo', 'bar');
-      $iterator = 0;
-      $result = $this->credis->zscan($iterator, 'set','*', 10);
-      $this->assertEquals($iterator, 0);
-      $this->assertEquals($result, false);
+        $this->credis->sadd('set', 'foo', 'bar');
+        $iterator = 0;
+        $result = $this->credis->zscan($iterator, 'set','*', 10);
+        $this->assertEquals($iterator, 0);
+        $this->assertEquals($result, false);
     }
 
     public function testZscan()
@@ -862,11 +862,11 @@ class CredisTest extends CredisTestCommon
 
     public function testZscanEmptyIterator()
     {
-      $this->credis->zadd('sortedset', 0, 'name');
-      $iterator = 0;
-      $result = $this->credis->zscan($iterator, 'sortedset','*', 10);
-      $this->assertEquals($iterator, 0);
-      $this->assertEquals($result, false);
+        $this->credis->zadd('sortedset', 0, 'name');
+        $iterator = 0;
+        $result = $this->credis->zscan($iterator, 'sortedset','*', 10);
+        $this->assertEquals($iterator, 0);
+        $this->assertEquals($result, false);
     }
 
     public function testscan()
@@ -893,11 +893,11 @@ class CredisTest extends CredisTestCommon
 
     public function testscanEmptyIterator()
     {
-      $this->credis->set('foo', 'bar');
-      $iterator = 0;
-      $result = $this->credis->scan($iterator, '*', 10);
-      $this->assertEquals($iterator, 0);
-      $this->assertEquals($result, false);
+        $this->credis->set('foo', 'bar');
+        $iterator = 0;
+        $result = $this->credis->scan($iterator, '*', 10);
+        $this->assertEquals($iterator, 0);
+        $this->assertEquals($result, false);
     }
 
   public function testPing()

--- a/tests/CredisTest.php
+++ b/tests/CredisTest.php
@@ -463,11 +463,19 @@ class CredisTest extends CredisTestCommon
                               ->exec();
         $this->assertEquals(array(3,4,3), $reply);
 
+        $reply = $this->credis->multi()
+                              ->incr('foo')
+                              ->pipeline()
+                              ->incr('foo')
+                              ->incr('bar')
+                              ->exec();
+        $this->assertEquals(array(5,6,4), $reply);
+
         $reply = $this->credis->multi()->pipeline()
                               ->incr('foo')
                               ->incr('bar')
                               ->exec();
-        $this->assertEquals(array(5,4), $reply);
+        $this->assertEquals(array(7,5), $reply);
 
         $reply = $this->credis->multi()
                               ->incr('foo')
@@ -475,7 +483,7 @@ class CredisTest extends CredisTestCommon
                               ->incr('foo')
                               ->incr('bar')
                               ->exec();
-        $this->assertEquals(array(6,7,5), $reply);
+        $this->assertEquals(array(8,9,6), $reply);
 
         $reply = $this->credis->multi()
                               ->set('a', 3)


### PR DESCRIPTION
- Fixes type hinting on for `scan`/`sscan`/`zscan`/`hscan `
- Aligns behavior of `scan`/`sscan`/`zscan`/`hscan` with phpredis of how an empty/falsy iterator is handled.
- Fix errors in `exec()` could cause the redis connection and credis internal state to become out of sync
- Prevent `scan`/`sscan`/`zscan`/`hscan` from being used in `pipeline`/`multi` mode, as phpredis would cause trigger a fatal php error instead of throwing an exception in this case
- Fix calling `mget([])` in standalone mode didn't match phpredis mode
- Fix `multi` mode failing when commands where issued between `multi()` and `pipeline()`. Recommended usage is however `pipeline()-> multi()->...->exec()`

This breaks pipeline mode for these functions as they return early, but mget was already doing this. Documented in #182