### PR TITLE
Fix for warning Trying to access array offset on value of type bool

### DIFF
--- a/Client.php
+++ b/Client.php
@@ -1153,10 +1153,10 @@ class Credis_Client
                         if ($this->isMulti) {
                             $execResponse = array_pop($response);
                             if(!empty($execResponse)) {
-                        	foreach ($queuedResponses as $key => $command) {
-                            	    list($name, $arguments) = $command;
-                            	    $response[] = $this->decode_reply($name, $execResponse[$key], $arguments);
-                        	}
+                                foreach ($queuedResponses as $key => $command) {
+                                    list($name, $arguments) = $command;
+                                    $response[] = $this->decode_reply($name, $execResponse[$key], $arguments);
+                                }
                     	    }
                         }
                     } catch (CredisException $e) {

--- a/Client.php
+++ b/Client.php
@@ -1152,8 +1152,7 @@ class Credis_Client
 
                         if ($this->isMulti) {
                             $execResponse = array_pop($response);
-                            if(!empty($execResponse))
-			    {
+                            if(!empty($execResponse)) {
                         	foreach ($queuedResponses as $key => $command) {
                             	    list($name, $arguments) = $command;
                             	    $response[] = $this->decode_reply($name, $execResponse[$key], $arguments);

--- a/Client.php
+++ b/Client.php
@@ -1152,10 +1152,13 @@ class Credis_Client
 
                         if ($this->isMulti) {
                             $execResponse = array_pop($response);
-                            foreach ($queuedResponses as $key => $command) {
-                                list($name, $arguments) = $command;
-                                $response[] = $this->decode_reply($name, $execResponse[$key], $arguments);
-                            }
+                            if(!empty($execResponse))
+			    {
+                        	foreach ($queuedResponses as $key => $command) {
+                            	    list($name, $arguments) = $command;
+                            	    $response[] = $this->decode_reply($name, $execResponse[$key], $arguments);
+                        	}
+                    	    }
                         }
                     } catch (CredisException $e) {
                         // the connection on redis's side is likely in a bad state, force it closed to abort the pipeline/transaction


### PR DESCRIPTION
Hi,

Using Magento 2.4.6-p2 open source and colinmollenhour/credis v1.16.0. Using a command line script I am getting this error:

PHP Warning: Trying to access array offset on value of type bool in colinmollenhour/credis/Client.php on line 1156

Not sure why this is happening. Have not debugged in depth, but

$execResponse = array_pop($response);

is actually false, so doing:

                        if(!empty($execResponse))
                        {
                            foreach ($queuedResponses as $key => $command) {
                                list($name, $arguments) = $command;
                                $response[] = $this->decode_reply($name, $execResponse[$key], $arguments);
                            }    
                        }
suppresses the warning.

Michael.