### PR TITLE
Update Cluster.php to fix issue with PHP version 8.3

### DIFF
--- a/Cluster.php
+++ b/Cluster.php
@@ -16,6 +16,11 @@
 class Credis_Cluster
 {
     /**
+     * Number of replicas for each server in the cluster
+     * @var int
+     */
+    protected $replicas;
+    /**
      * Collection of Credis_Client objects attached to Redis servers
      * @var Credis_Client[]
      */


### PR DESCRIPTION
Need to declare this variable on top on PHP version 3 or we will get the warning: Deprecated: Creation of dynamic property Credis_Cluster::$replicas is deprecated in vendor/colinmollenhour/credis/Cluster.php on line 86