### PR TITLE
Improve checks for what makes a replica/slave being considered "down"

### DIFF
--- a/Sentinel.php
+++ b/Sentinel.php
@@ -239,7 +239,7 @@ class Credis_Sentinel
             }
 
             $flags = explode(',', $flags);
-            if (!array_intersect($flags, ['s_down', 'o_down', 'disconnected'])){
+            if (!array_intersect($flags, ['s_down', 'o_down', 'disconnected'])) {
                 $workingSlaves[] = new Credis_Client($replica['ip'], $replica['port'], $this->_timeout, $this->_persistent, $this->_db, $this->_password, $this->_username);
             }
         }

--- a/Sentinel.php
+++ b/Sentinel.php
@@ -222,13 +222,25 @@ class Credis_Sentinel
     public function createSlaveClients($name)
     {
         $slaves = $this->slaves($name);
-        $workingSlaves = array();
-        foreach ($slaves as $slave) {
-            if (!isset($slave[9])) {
+        $workingSlaves = [];
+        foreach ($slaves as $slaveRaw) {
+            $replica = [];
+            for ($i = 0; $i < count($slaveRaw) - 1; $i += 2) {
+                $replica[$slaveRaw[$i]] = $slaveRaw[$i + 1];
+            }
+
+            $flags = $replica['flags'] ?? null;
+            if ($flags === null) {
                 throw new CredisException('Can\' retrieve slave status');
             }
-            if (!strstr($slave[9], 's_down') && !strstr($slave[9], 'disconnected')) {
-                $workingSlaves[] = new Credis_Client($slave[3], $slave[5], $this->_timeout, $this->_persistent, $this->_db, $this->_password, $this->_username);
+
+            if (($replica['master-link-status'] ?? '') === 'err') {
+                continue;
+            }
+
+            $flags = explode(',', $flags);
+            if (!array_intersect($flags, ['s_down', 'o_down', 'disconnected'])){
+                $workingSlaves[] = new Credis_Client($replica['ip'], $replica['port'], $this->_timeout, $this->_persistent, $this->_db, $this->_password, $this->_username);
             }
         }
         return $workingSlaves;


### PR DESCRIPTION
The documentation appears to be the source; https://github.com/redis/redis/blob/8.6/src/sentinel.c#L3406-L3422

The replica command returns a bulk reply with in the form of a key:value in a flat list. Nothing prevents the magic index changing, so transform into a php hash array and do the lookups on the more stable name.

The return result of the replicas command in the RESP3 protocol version actually changes to match the key:value hash type instead of the flat list. I've got an old partial support for the RESP3 protocol, but I haven't had a need to complete it.